### PR TITLE
Fix Read the Docs setup and improve documentation structure

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/libraries/sg13g2_stdcell/cells/index.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/index.rst
@@ -1,8 +1,355 @@
 Standard Cells
 ==============
 
+.. list-table:: List of cells in sg13g2_stdcell
+   :header-rows: 1
+   :widths: 20 40 10 30
+
+   * - Cell name
+     - Description
+     - Type
+     - Verilog name
+   * - :doc:`sg13g2_a21o_1`
+     - 2-input AND into first input of 2-input OR.
+     - cell
+     - sg13g2_a21o_1
+   * - :doc:`sg13g2_a21o_2`
+     - 2-input AND into first input of 2-input OR.
+     - cell
+     - sg13g2_a21o_2
+   * - :doc:`sg13g2_a21oi_1`
+     - 2-input AND into first input of 2-input NOR.
+     - cell
+     - sg13g2_a21oi_1
+   * - :doc:`sg13g2_a21oi_2`
+     - 2-input AND into first input of 2-input NOR.
+     - cell
+     - sg13g2_a21oi_2
+   * - :doc:`sg13g2_a221oi_1`
+     - 2-input AND into first two inputs of 3-input NOR.
+     - cell
+     - sg13g2_a221oi_1
+   * - :doc:`sg13g2_a22oi_1`
+     - 2-input AND into both inputs of 2-input NOR.
+     - cell
+     - sg13g2_a22oi_1
+   * - :doc:`sg13g2_and2_1`
+     - 2-input AND
+     - cell
+     - sg13g2_and2_1
+   * - :doc:`sg13g2_and2_2`
+     - 2-input AND
+     - cell
+     - sg13g2_and2_2
+   * - :doc:`sg13g2_and3_1`
+     - 3-input AND
+     - cell
+     - sg13g2_and3_1
+   * - :doc:`sg13g2_and3_2`
+     - 3-input AND
+     - cell
+     - sg13g2_and3_2
+   * - :doc:`sg13g2_and4_1`
+     - 4-input AND
+     - cell
+     - sg13g2_and4_1
+   * - :doc:`sg13g2_and4_2`
+     - 4-input AND
+     - cell
+     - sg13g2_and4_2
+   * - :doc:`sg13g2_antennanp`
+     - Antenna effect protection cell (gate charge) at manufacture, P-diode in N-Well, N-diode in substrate
+     - cell
+     - sg13g2_antennanp
+   * - :doc:`sg13g2_buf_1`
+     - Buffer drive strength 1
+     - cell
+     - sg13g2_buf_1
+   * - :doc:`sg13g2_buf_16`
+     - Buffer drive strength 16
+     - cell
+     - sg13g2_buf_16
+   * - :doc:`sg13g2_buf_2`
+     - Buffer drive strength 2
+     - cell
+     - sg13g2_buf_2
+   * - :doc:`sg13g2_buf_4`
+     - Buffer drive strength 4
+     - cell
+     - sg13g2_buf_4
+   * - :doc:`sg13g2_buf_8`
+     - Buffer drive strength 8
+     - cell
+     - sg13g2_buf_8
+   * - :doc:`sg13g2_decap_4`
+     - Decoupling capasitance filler cell
+     - cell
+     - sg13g2_decap_4
+   * - :doc:`sg13g2_decap_8`
+     - Decoupling capasitance filler cell
+     - cell
+     - sg13g2_decap_8
+   * - :doc:`sg13g2_dfrbp_1`
+     - Posedge Two-Outputs Q and Q_N D-Flip-Flop with Low-Active Reset
+     - cell
+     - sg13g2_dfrbp_1
+   * - :doc:`sg13g2_dfrbp_2`
+     - Posedge Two-Outputs Q and Q_N D-Flip-Flop with Low-Active Reset
+     - cell
+     - sg13g2_dfrbp_2
+   * - :doc:`sg13g2_dfrbpq_1`
+     - Posedge Single-Output Q D-Flip-Flop with Low-Active Reset
+     - cell
+     - sg13g2_dfrbpq_1
+   * - :doc:`sg13g2_dfrbpq_2`
+     - Posedge Single-Output Q D-Flip-Flop with Low-Active Reset
+     - cell
+     - sg13g2_dfrbpq_2
+   * - :doc:`sg13g2_dlhq_1`
+     - High-Active GATE Single-Output Q D-latch
+     - cell
+     - sg13g2_dlhq_1
+   * - :doc:`sg13g2_dlhr_1`
+     - High-Active GATE Two-Outputs Q Q_N D-latch with Low-Active Reset
+     - cell
+     - sg13g2_dlhr_1
+   * - :doc:`sg13g2_dlhrq_1`
+     - High-Active Gate Single-Output Q D-latch with Low-Active Reset
+     - cell
+     - sg13g2_dlhrq_1
+   * - :doc:`sg13g2_dllr_1`
+     - Low-Active GATE_N Two-Outputs Q Q_N D-latch with Low-Active Reset
+     - cell
+     - sg13g2_dllr_1
+   * - :doc:`sg13g2_dllrq_1`
+     - Low-Active GATE_N Single-Output Q D-latch with Low-Active Reset
+     - cell
+     - sg13g2_dllrq_1
+   * - :doc:`sg13g2_dlygate4sd1_1`
+     - Delay Cell, typical 0.4 ns
+     - cell
+     - sg13g2_dlygate4sd1_1
+   * - :doc:`sg13g2_dlygate4sd2_1`
+     - Delay Cell, typical 0.45 ns
+     - cell
+     - sg13g2_dlygate4sd2_1
+   * - :doc:`sg13g2_dlygate4sd3_1`
+     - Delay Cell, typical 0.7 ns
+     - cell
+     - sg13g2_dlygate4sd3_1
+   * - :doc:`sg13g2_ebufn_2`
+     - Tristate Buffer with Low-Active Enable TE_B
+     - cell
+     - sg13g2_ebufn_2
+   * - :doc:`sg13g2_ebufn_4`
+     - Tristate Buffer with Low-Active Enable TE_B
+     - cell
+     - sg13g2_ebufn_4
+   * - :doc:`sg13g2_ebufn_8`
+     - Tristate Buffer with Low-Active Enable TE_B
+     - cell
+     - sg13g2_ebufn_8
+   * - :doc:`sg13g2_einvn_2`
+     - Tristate Inverter with Low-Active Enable TE_B
+     - cell
+     - sg13g2_einvn_2
+   * - :doc:`sg13g2_einvn_4`
+     - Tristate Inverter with Low-Active Enable TE_B
+     - cell
+     - sg13g2_einvn_4
+   * - :doc:`sg13g2_einvn_8`
+     - Tristate Inverter with Low-Active Enable TE_B
+     - cell
+     - sg13g2_einvn_8
+   * - :doc:`sg13g2_fill_1`
+     - Filler 1 Track Width
+     - cell
+     - sg13g2_fill_1
+   * - :doc:`sg13g2_fill_2`
+     - Filler 2 Tracks Width
+     - cell
+     - sg13g2_fill_2
+   * - :doc:`sg13g2_fill_4`
+     - Filler 4 Tracks Width
+     - cell
+     - sg13g2_fill_4
+   * - :doc:`sg13g2_fill_8`
+     - Filler 8 Tracks Width
+     - cell
+     - sg13g2_fill_8
+   * - :doc:`sg13g2_inv_1`
+     - Inverter
+     - cell
+     - sg13g2_inv_1
+   * - :doc:`sg13g2_inv_16`
+     - Inverter
+     - cell
+     - sg13g2_inv_16
+   * - :doc:`sg13g2_inv_2`
+     - Inverter
+     - cell
+     - sg13g2_inv_2
+   * - :doc:`sg13g2_inv_4`
+     - Inverter
+     - cell
+     - sg13g2_inv_4
+   * - :doc:`sg13g2_inv_8`
+     - Inverter
+     - cell
+     - sg13g2_inv_8
+   * - :doc:`sg13g2_lgcp_1`
+     - Posedge Clock Gating cell, Low Latch Enable
+     - cell
+     - sg13g2_lgcp_1
+   * - :doc:`sg13g2_mux2_1`
+     - Multiplexer from 2 to 1
+     - cell
+     - sg13g2_mux2_1
+   * - :doc:`sg13g2_mux2_2`
+     - Multiplexer from 2 to 1
+     - cell
+     - sg13g2_mux2_2
+   * - :doc:`sg13g2_mux4_1`
+     - Multiplexer from 4 to 1
+     - cell
+     - sg13g2_mux4_1
+   * - :doc:`sg13g2_nand2_1`
+     - 2-input NAND
+     - cell
+     - sg13g2_nand2_1
+   * - :doc:`sg13g2_nand2_2`
+     - 2-input NAND
+     - cell
+     - sg13g2_nand2_2
+   * - :doc:`sg13g2_nand2b_1`
+     - 2-input NAND with Inverted Input A_N
+     - cell
+     - sg13g2_nand2b_1
+   * - :doc:`sg13g2_nand2b_2`
+     - 2-input NAND with Inverted Input A_N
+     - cell
+     - sg13g2_nand2b_2
+   * - :doc:`sg13g2_nand3_1`
+     - 3-input NAND
+     - cell
+     - sg13g2_nand3_1
+   * - :doc:`sg13g2_nand3b_1`
+     - 3-input NAND3 with Inverted Input A_N
+     - cell
+     - sg13g2_nand3b_1
+   * - :doc:`sg13g2_nand4_1`
+     - 4-input NAND
+     - cell
+     - sg13g2_nand4_1
+   * - :doc:`sg13g2_nor2_1`
+     - 2-input NOR
+     - cell
+     - sg13g2_nor2_1
+   * - :doc:`sg13g2_nor2_2`
+     - 2-input NOR
+     - cell
+     - sg13g2_nor2_2
+   * - :doc:`sg13g2_nor2b_1`
+     - 2-input NOR2 with Inverted Input B_N
+     - cell
+     - sg13g2_nor2b_1
+   * - :doc:`sg13g2_nor2b_2`
+     - 2-input NOR2 with Inverted Input B_N
+     - cell
+     - sg13g2_nor2b_2
+   * - :doc:`sg13g2_nor3_1`
+     - 3-input NOR
+     - cell
+     - sg13g2_nor3_1
+   * - :doc:`sg13g2_nor3_2`
+     - 3-input NOR
+     - cell
+     - sg13g2_nor3_2
+   * - :doc:`sg13g2_nor4_1`
+     - 4-input NOR
+     - cell
+     - sg13g2_nor4_1
+   * - :doc:`sg13g2_nor4_2`
+     - 4-input NOR
+     - cell
+     - sg13g2_nor4_2
+   * - :doc:`sg13g2_o21ai_1`
+     - 2-input OR into 2-input NAND
+     - cell
+     - sg13g2_o21ai_1
+   * - :doc:`sg13g2_or2_1`
+     - 2-input OR
+     - cell
+     - sg13g2_or2_1
+   * - :doc:`sg13g2_or2_2`
+     - 2-input OR
+     - cell
+     - sg13g2_or2_2
+   * - :doc:`sg13g2_or3_1`
+     - 3-input OR
+     - cell
+     - sg13g2_or3_1
+   * - :doc:`sg13g2_or3_2`
+     - 3-input OR
+     - cell
+     - sg13g2_or3_2
+   * - :doc:`sg13g2_or4_1`
+     - 4-input OR
+     - cell
+     - sg13g2_or4_1
+   * - :doc:`sg13g2_or4_2`
+     - 4-input OR
+     - cell
+     - sg13g2_or4_2
+   * - :doc:`sg13g2_sdfbbp_1`
+     - Posedge Two-Outputs D-Flip-Flop with Reset, Set and Scan
+     - cell
+     - sg13g2_sdfbbp_1
+   * - :doc:`sg13g2_sdfrbp_1`
+     - Posedge Two-Outputs Q and Q_N D-Flip-Flop with Reset and Scan
+     - cell
+     - sg13g2_sdfrbp_1
+   * - :doc:`sg13g2_sdfrbp_2`
+     - Posedge Two-Outputs Q and Q_N D-Flip-Flop with Reset and Scan
+     - cell
+     - sg13g2_sdfrbp_2
+   * - :doc:`sg13g2_sdfrbpq_1`
+     - Posedge Single-Output Q D-Flip-Flop with Reset and Scan
+     - cell
+     - sg13g2_sdfrbpq_1
+   * - :doc:`sg13g2_sdfrbpq_2`
+     - Posedge Single-Output Q D-Flip-Flop with Reset and Scan
+     - cell
+     - sg13g2_sdfrbpq_2
+   * - :doc:`sg13g2_slgcp_1`
+     - Scan gated clock
+     - cell
+     - sg13g2_slgcp_1
+   * - :doc:`sg13g2_sighold`
+     - Leakage current compensator (bus holder)
+     - cell
+     - sg13g2_sighold
+   * - :doc:`sg13g2_tiehi`
+     - Constant logic 0
+     - cell
+     - sg13g2_tiehi
+   * - :doc:`sg13g2_tielo`
+     - Constant logic 1
+     - cell
+     - sg13g2_tielo
+   * - :doc:`sg13g2_xnor2_1`
+     - 2-input XNOR
+     - cell
+     - sg13g2_xnor2_1
+   * - :doc:`sg13g2_xor2_1`
+     - 2-input XOR
+     - cell
+     - sg13g2_xor2_1
+
+
 .. toctree::
    :maxdepth: 1
+   :hidden:
 
    sg13g2_a21o_1
    sg13g2_a21o_2
@@ -82,8 +429,8 @@ Standard Cells
    sg13g2_sdfrbp_2
    sg13g2_sdfrbpq_1
    sg13g2_sdfrbpq_2
-   sg13g2_sighold
    sg13g2_slgcp_1
+   sg13g2_sighold
    sg13g2_tiehi
    sg13g2_tielo
    sg13g2_xnor2_1

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21o_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21o_1.rst
@@ -1,7 +1,7 @@
 sg13g2_a21o_1
 =============
 
-**AO21**
+2-input AND into first input of 2-input OR.
 
 -  **Cell name**: sg13g2_a21o_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21o_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21o_2.rst
@@ -1,7 +1,7 @@
 sg13g2_a21o_2
 =============
 
-**AO21**
+2-input AND into first input of 2-input OR.
 
 -  **Cell name**: sg13g2_a21o_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21oi_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21oi_1.rst
@@ -1,7 +1,7 @@
 sg13g2_a21oi_1
 ==============
 
-**a21oi**
+2-input AND into first input of 2-input NOR.
 
 -  **Cell name**: sg13g2_a21oi_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21oi_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21oi_2.rst
@@ -1,7 +1,7 @@
 sg13g2_a21oi_2
 ==============
 
-**a21oi**
+2-input AND into first input of 2-input NOR.
 
 -  **Cell name**: sg13g2_a21oi_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a221oi_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a221oi_1.rst
@@ -1,7 +1,7 @@
 sg13g2_a221oi_1
 ===============
 
-**a221oi**
+2-input AND into first two inputs of 3-input NOR.
 
 -  **Cell name**: sg13g2_a221oi_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a22oi_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a22oi_1.rst
@@ -1,7 +1,7 @@
 sg13g2_a22oi_1
 ==============
 
-**a22oi**
+2-input AND into both inputs of 2-input NOR.
 
 -  **Cell name**: sg13g2_a22oi_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and2_1.rst
@@ -1,7 +1,7 @@
 sg13g2_and2_1
 =============
 
-**AND2**
+2-input AND
 
 -  **Cell name**: sg13g2_and2_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and2_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and2_2.rst
@@ -1,7 +1,7 @@
 sg13g2_and2_2
 =============
 
-**AND2**
+2-input AND
 
 -  **Cell name**: sg13g2_and2_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and3_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and3_1.rst
@@ -1,7 +1,7 @@
 sg13g2_and3_1
 =============
 
-**AND3**
+3-input AND
 
 -  **Cell name**: sg13g2_and3_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and3_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and3_2.rst
@@ -1,7 +1,7 @@
 sg13g2_and3_2
 =============
 
-**AND3**
+3-input AND
 
 -  **Cell name**: sg13g2_and3_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and4_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and4_1.rst
@@ -1,7 +1,7 @@
 sg13g2_and4_1
 =============
 
-**AND4**
+4-input AND
 
 -  **Cell name**: sg13g2_and4_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and4_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and4_2.rst
@@ -1,7 +1,7 @@
 sg13g2_and4_2
 =============
 
-**AND4**
+4-input AND
 
 -  **Cell name**: sg13g2_and4_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_antennanp.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_antennanp.rst
@@ -1,7 +1,7 @@
 sg13g2_antennanp
 ================
 
-**NP_ant**
+Antenna effect protection cell (gate charge) at manufacture, P-diode in N-Well, N-diode in substrate
 
 -  **Cell name**: sg13g2_antennanp
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_1.rst
@@ -1,7 +1,7 @@
 sg13g2_buf_1
 ============
 
-**BU**
+Buffer drive strength 1
 
 -  **Cell name**: sg13g2_buf_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_16.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_16.rst
@@ -1,7 +1,7 @@
 sg13g2_buf_16
 =============
 
-**BU**
+Buffer drive strength 16
 
 -  **Cell name**: sg13g2_buf_16
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_2.rst
@@ -1,7 +1,7 @@
 sg13g2_buf_2
 ============
 
-**BU**
+Buffer drive strength 2
 
 -  **Cell name**: sg13g2_buf_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_4.rst
@@ -1,7 +1,7 @@
 sg13g2_buf_4
 ============
 
-**BU**
+Buffer drive strength 4
 
 -  **Cell name**: sg13g2_buf_4
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_8.rst
@@ -1,7 +1,7 @@
 sg13g2_buf_8
 ============
 
-**BU**
+Buffer drive strength 8
 
 -  **Cell name**: sg13g2_buf_8
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_decap_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_decap_4.rst
@@ -1,7 +1,7 @@
 sg13g2_decap_4
 ==============
 
-**DECAP**
+Decoupling capasitance filler cell
 
 -  **Cell name**: sg13g2_decap_4
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_decap_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_decap_8.rst
@@ -1,7 +1,7 @@
 sg13g2_decap_8
 ==============
 
-**DECAP**
+Decoupling capasitance filler cell
 
 -  **Cell name**: sg13g2_decap_8
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbp_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbp_1.rst
@@ -1,13 +1,13 @@
 sg13g2_dfrbp_1
 ==============
 
-**dffrr**
+Posedge Two-Outputs Q and Q_N D-Flip-Flop with Low-Active Reset
 
 -  **Cell name**: sg13g2_dfrbp_1
 -  **Type**: cell
 -  **Verilog name**: sg13g2_dfrbp_1
 -  **Library**: sg13g2_stdcell
--  **Inputs**:  3 (D, RESET_B, CLK)
+-  **Inputs**:  3 (CLK, D, RESET_B)
 -  **Outputs**: 2 (Q, Q_N)
 
 sg13g2_dfrbp_1 GDSII layouts

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbp_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbp_2.rst
@@ -1,13 +1,13 @@
 sg13g2_dfrbp_2
 ==============
 
-**dffrr**
+Posedge Two-Outputs Q and Q_N D-Flip-Flop with Low-Active Reset
 
 -  **Cell name**: sg13g2_dfrbp_2
 -  **Type**: cell
 -  **Verilog name**: sg13g2_dfrbp_2
 -  **Library**: sg13g2_stdcell
--  **Inputs**:  3 (D, RESET_B, CLK)
+-  **Inputs**:  3 (CLK, D, RESET_B)
 -  **Outputs**: 2 (Q, Q_N)
 
 sg13g2_dfrbp_2 GDSII layouts

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbpq_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbpq_1.rst
@@ -1,13 +1,13 @@
 sg13g2_dfrbpq_1
 ===============
 
-**dfrbpq**
+Posedge Single-Output Q D-Flip-Flop with Low-Active Reset
 
 -  **Cell name**: sg13g2_dfrbpq_1
 -  **Type**: cell
 -  **Verilog name**: sg13g2_dfrbpq_1
 -  **Library**: sg13g2_stdcell
--  **Inputs**:  3 (D, RESET_B, CLK)
+-  **Inputs**:  3 (CLK, D, RESET_B)
 -  **Outputs**: 1 (Q)
 
 sg13g2_dfrbpq_1 GDSII layouts

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbpq_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbpq_2.rst
@@ -1,13 +1,13 @@
 sg13g2_dfrbpq_2
 ===============
 
-**dfrbpq**
+Posedge Single-Output Q D-Flip-Flop with Low-Active Reset
 
 -  **Cell name**: sg13g2_dfrbpq_2
 -  **Type**: cell
 -  **Verilog name**: sg13g2_dfrbpq_2
 -  **Library**: sg13g2_stdcell
--  **Inputs**:  3 (D, RESET_B, CLK)
+-  **Inputs**:  3 (CLK, D, RESET_B)
 -  **Outputs**: 1 (Q)
 
 sg13g2_dfrbpq_2 GDSII layouts

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhq_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhq_1.rst
@@ -1,7 +1,7 @@
 sg13g2_dlhq_1
 =============
 
-**DLHQ**
+High-Active GATE Single-Output Q D-latch
 
 -  **Cell name**: sg13g2_dlhq_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhr_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhr_1.rst
@@ -1,13 +1,13 @@
 sg13g2_dlhr_1
 =============
 
-**DLHR**
+High-Active GATE Two-Outputs Q Q_N D-latch with Low-Active Reset
 
 -  **Cell name**: sg13g2_dlhr_1
 -  **Type**: cell
 -  **Verilog name**: sg13g2_dlhr_1
 -  **Library**: sg13g2_stdcell
--  **Inputs**:  3 (D, RESET_B, GATE)
+-  **Inputs**:  3 (D, GATE, RESET_B)
 -  **Outputs**: 2 (Q, Q_N)
 
 sg13g2_dlhr_1 GDSII layouts

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhrq_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhrq_1.rst
@@ -1,13 +1,13 @@
 sg13g2_dlhrq_1
 ==============
 
-**DLHRQ**
+High-Active Gate Single-Output Q D-latch with Low-Active Reset
 
 -  **Cell name**: sg13g2_dlhrq_1
 -  **Type**: cell
 -  **Verilog name**: sg13g2_dlhrq_1
 -  **Library**: sg13g2_stdcell
--  **Inputs**:  3 (D, RESET_B, GATE)
+-  **Inputs**:  3 (D, GATE, RESET_B)
 -  **Outputs**: 1 (Q)
 
 sg13g2_dlhrq_1 GDSII layouts

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dllr_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dllr_1.rst
@@ -1,13 +1,13 @@
 sg13g2_dllr_1
 =============
 
-**DLLR**
+Low-Active GATE_N Two-Outputs Q Q_N D-latch with Low-Active Reset
 
 -  **Cell name**: sg13g2_dllr_1
 -  **Type**: cell
 -  **Verilog name**: sg13g2_dllr_1
 -  **Library**: sg13g2_stdcell
--  **Inputs**:  3 (D, RESET_B, GATE_N)
+-  **Inputs**:  3 (D, GATE_N, RESET_B)
 -  **Outputs**: 2 (Q, Q_N)
 
 sg13g2_dllr_1 GDSII layouts

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dllrq_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dllrq_1.rst
@@ -1,13 +1,13 @@
 sg13g2_dllrq_1
 ==============
 
-**DLLRQ**
+Low-Active GATE_N Single-Output Q D-latch with Low-Active Reset
 
 -  **Cell name**: sg13g2_dllrq_1
 -  **Type**: cell
 -  **Verilog name**: sg13g2_dllrq_1
 -  **Library**: sg13g2_stdcell
--  **Inputs**:  3 (D, RESET_B, GATE_N)
+-  **Inputs**:  3 (D, GATE_N, RESET_B)
 -  **Outputs**: 1 (Q)
 
 sg13g2_dllrq_1 GDSII layouts

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd1_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd1_1.rst
@@ -1,7 +1,7 @@
 sg13g2_dlygate4sd1_1
 ====================
 
-**DLY1**
+Delay Cell, typical 0.4 ns
 
 -  **Cell name**: sg13g2_dlygate4sd1_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd2_1.rst
@@ -1,7 +1,7 @@
 sg13g2_dlygate4sd2_1
 ====================
 
-**DLY2**
+Delay Cell, typical 0.45 ns
 
 -  **Cell name**: sg13g2_dlygate4sd2_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd3_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd3_1.rst
@@ -1,7 +1,7 @@
 sg13g2_dlygate4sd3_1
 ====================
 
-**DLY4**
+Delay Cell, typical 0.7 ns
 
 -  **Cell name**: sg13g2_dlygate4sd3_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_2.rst
@@ -1,7 +1,7 @@
 sg13g2_ebufn_2
 ==============
 
-**BTL**
+Tristate Buffer with Low-Active Enable TE_B
 
 -  **Cell name**: sg13g2_ebufn_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_4.rst
@@ -1,7 +1,7 @@
 sg13g2_ebufn_4
 ==============
 
-**BTL**
+Tristate Buffer with Low-Active Enable TE_B
 
 -  **Cell name**: sg13g2_ebufn_4
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_8.rst
@@ -1,7 +1,7 @@
 sg13g2_ebufn_8
 ==============
 
-**BTL**
+Tristate Buffer with Low-Active Enable TE_B
 
 -  **Cell name**: sg13g2_ebufn_8
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_2.rst
@@ -1,7 +1,7 @@
 sg13g2_einvn_2
 ==============
 
-**einvin**
+Tristate Inverter with Low-Active Enable TE_B
 
 -  **Cell name**: sg13g2_einvn_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_4.rst
@@ -1,7 +1,7 @@
 sg13g2_einvn_4
 ==============
 
-**einvin**
+Tristate Inverter with Low-Active Enable TE_B
 
 -  **Cell name**: sg13g2_einvn_4
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_8.rst
@@ -1,7 +1,7 @@
 sg13g2_einvn_8
 ==============
 
-**ITL**
+Tristate Inverter with Low-Active Enable TE_B
 
 -  **Cell name**: sg13g2_einvn_8
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_1.rst
@@ -1,7 +1,7 @@
 sg13g2_fill_1
 =============
 
-**fill**
+Filler 1 Track Width
 
 -  **Cell name**: sg13g2_fill_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_2.rst
@@ -1,7 +1,7 @@
 sg13g2_fill_2
 =============
 
-**fill**
+Filler 2 Tracks Width
 
 -  **Cell name**: sg13g2_fill_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_4.rst
@@ -1,7 +1,7 @@
 sg13g2_fill_4
 =============
 
-**fill**
+Filler 4 Tracks Width
 
 -  **Cell name**: sg13g2_fill_4
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_8.rst
@@ -1,7 +1,7 @@
 sg13g2_fill_8
 =============
 
-**fill**
+Filler 8 Tracks Width
 
 -  **Cell name**: sg13g2_fill_8
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_1.rst
@@ -1,7 +1,7 @@
 sg13g2_inv_1
 ============
 
-**IN**
+Inverter
 
 -  **Cell name**: sg13g2_inv_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_16.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_16.rst
@@ -1,7 +1,7 @@
 sg13g2_inv_16
 =============
 
-**IN**
+Inverter
 
 -  **Cell name**: sg13g2_inv_16
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_2.rst
@@ -1,7 +1,7 @@
 sg13g2_inv_2
 ============
 
-**IN**
+Inverter
 
 -  **Cell name**: sg13g2_inv_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_4.rst
@@ -1,7 +1,7 @@
 sg13g2_inv_4
 ============
 
-**IN**
+Inverter
 
 -  **Cell name**: sg13g2_inv_4
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_8.rst
@@ -1,7 +1,7 @@
 sg13g2_inv_8
 ============
 
-**IN**
+Inverter
 
 -  **Cell name**: sg13g2_inv_8
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_lgcp_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_lgcp_1.rst
@@ -1,13 +1,13 @@
 sg13g2_lgcp_1
 =============
 
-**gclk**
+Posedge Clock Gating cell, Low Latch Enable
 
 -  **Cell name**: sg13g2_lgcp_1
 -  **Type**: cell
 -  **Verilog name**: sg13g2_lgcp_1
 -  **Library**: sg13g2_stdcell
--  **Inputs**:  2 (GATE, CLK)
+-  **Inputs**:  2 (CLK, GATE)
 -  **Outputs**: 1 (GCLK)
 
 sg13g2_lgcp_1 GDSII layouts

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux2_1.rst
@@ -1,7 +1,7 @@
 sg13g2_mux2_1
 =============
 
-**mux2**
+Multiplexer from 2 to 1
 
 -  **Cell name**: sg13g2_mux2_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux2_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux2_2.rst
@@ -1,7 +1,7 @@
 sg13g2_mux2_2
 =============
 
-**mux2**
+Multiplexer from 2 to 1
 
 -  **Cell name**: sg13g2_mux2_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux4_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux4_1.rst
@@ -1,7 +1,7 @@
 sg13g2_mux4_1
 =============
 
-**mux4**
+Multiplexer from 4 to 1
 
 -  **Cell name**: sg13g2_mux4_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2_1.rst
@@ -1,7 +1,7 @@
 sg13g2_nand2_1
 ==============
 
-**nand2**
+2-input NAND
 
 -  **Cell name**: sg13g2_nand2_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2_2.rst
@@ -1,7 +1,7 @@
 sg13g2_nand2_2
 ==============
 
-**nand2**
+2-input NAND
 
 -  **Cell name**: sg13g2_nand2_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2b_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2b_1.rst
@@ -1,7 +1,7 @@
 sg13g2_nand2b_1
 ===============
 
-**nand2b1**
+2-input NAND with Inverted Input A_N
 
 -  **Cell name**: sg13g2_nand2b_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2b_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2b_2.rst
@@ -1,7 +1,7 @@
 sg13g2_nand2b_2
 ===============
 
-**nand2b2**
+2-input NAND with Inverted Input A_N
 
 -  **Cell name**: sg13g2_nand2b_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand3_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand3_1.rst
@@ -1,7 +1,7 @@
 sg13g2_nand3_1
 ==============
 
-**nand3**
+3-input NAND
 
 -  **Cell name**: sg13g2_nand3_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand3b_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand3b_1.rst
@@ -1,7 +1,7 @@
 sg13g2_nand3b_1
 ===============
 
-**nand3b1**
+3-input NAND3 with Inverted Input A_N
 
 -  **Cell name**: sg13g2_nand3b_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand4_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand4_1.rst
@@ -1,7 +1,7 @@
 sg13g2_nand4_1
 ==============
 
-**nand4**
+4-input NAND
 
 -  **Cell name**: sg13g2_nand4_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2_1.rst
@@ -1,7 +1,7 @@
 sg13g2_nor2_1
 =============
 
-**nor2**
+2-input NOR
 
 -  **Cell name**: sg13g2_nor2_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2_2.rst
@@ -1,7 +1,7 @@
 sg13g2_nor2_2
 =============
 
-**nor2**
+2-input NOR
 
 -  **Cell name**: sg13g2_nor2_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2b_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2b_1.rst
@@ -1,7 +1,7 @@
 sg13g2_nor2b_1
 ==============
 
-**nor2b**
+2-input NOR2 with Inverted Input B_N
 
 -  **Cell name**: sg13g2_nor2b_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2b_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2b_2.rst
@@ -1,7 +1,7 @@
 sg13g2_nor2b_2
 ==============
 
-**nor2b**
+2-input NOR2 with Inverted Input B_N
 
 -  **Cell name**: sg13g2_nor2b_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor3_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor3_1.rst
@@ -1,7 +1,7 @@
 sg13g2_nor3_1
 =============
 
-**nor3**
+3-input NOR
 
 -  **Cell name**: sg13g2_nor3_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor3_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor3_2.rst
@@ -1,7 +1,7 @@
 sg13g2_nor3_2
 =============
 
-**nor3**
+3-input NOR
 
 -  **Cell name**: sg13g2_nor3_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor4_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor4_1.rst
@@ -1,7 +1,7 @@
 sg13g2_nor4_1
 =============
 
-**nor4**
+4-input NOR
 
 -  **Cell name**: sg13g2_nor4_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor4_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor4_2.rst
@@ -1,7 +1,7 @@
 sg13g2_nor4_2
 =============
 
-**nor4**
+4-input NOR
 
 -  **Cell name**: sg13g2_nor4_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_o21ai_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_o21ai_1.rst
@@ -1,7 +1,7 @@
 sg13g2_o21ai_1
 ==============
 
-**o21ai**
+2-input OR into 2-input NAND
 
 -  **Cell name**: sg13g2_o21ai_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or2_1.rst
@@ -1,7 +1,7 @@
 sg13g2_or2_1
 ============
 
-**or2**
+2-input OR
 
 -  **Cell name**: sg13g2_or2_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or2_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or2_2.rst
@@ -1,7 +1,7 @@
 sg13g2_or2_2
 ============
 
-**or2**
+2-input OR
 
 -  **Cell name**: sg13g2_or2_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or3_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or3_1.rst
@@ -1,7 +1,7 @@
 sg13g2_or3_1
 ============
 
-**or3**
+3-input OR
 
 -  **Cell name**: sg13g2_or3_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or3_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or3_2.rst
@@ -1,7 +1,7 @@
 sg13g2_or3_2
 ============
 
-**or3**
+3-input OR
 
 -  **Cell name**: sg13g2_or3_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or4_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or4_1.rst
@@ -1,7 +1,7 @@
 sg13g2_or4_1
 ============
 
-**or4**
+4-input OR
 
 -  **Cell name**: sg13g2_or4_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or4_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or4_2.rst
@@ -1,7 +1,7 @@
 sg13g2_or4_2
 ============
 
-**or4**
+4-input OR
 
 -  **Cell name**: sg13g2_or4_2
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfbbp_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfbbp_1.rst
@@ -1,13 +1,13 @@
 sg13g2_sdfbbp_1
 ===============
 
-**sdfrrs**
+Posedge Two-Outputs D-Flip-Flop with Reset, Set and Scan
 
 -  **Cell name**: sg13g2_sdfbbp_1
 -  **Type**: cell
 -  **Verilog name**: sg13g2_sdfbbp_1
 -  **Library**: sg13g2_stdcell
--  **Inputs**:  6 (D, SCD, SCE, RESET_B, SET_B, CLK)
+-  **Inputs**:  6 (CLK, D, RESET_B, SCD, SCE, SET_B)
 -  **Outputs**: 2 (Q, Q_N)
 
 sg13g2_sdfbbp_1 GDSII layouts

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbp_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbp_1.rst
@@ -1,13 +1,13 @@
 sg13g2_sdfrbp_1
 ===============
 
-**sdfrbp**
+Posedge Two-Outputs Q and Q_N D-Flip-Flop with Reset and Scan
 
 -  **Cell name**: sg13g2_sdfrbp_1
 -  **Type**: cell
 -  **Verilog name**: sg13g2_sdfrbp_1
 -  **Library**: sg13g2_stdcell
--  **Inputs**:  5 (D, SCD, SCE, RESET_B, CLK)
+-  **Inputs**:  5 (CLK, D, RESET_B, SCD, SCE)
 -  **Outputs**: 2 (Q, Q_N)
 
 sg13g2_sdfrbp_1 GDSII layouts

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbp_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbp_2.rst
@@ -1,13 +1,13 @@
 sg13g2_sdfrbp_2
 ===============
 
-**sdfrbp**
+Posedge Two-Outputs Q and Q_N D-Flip-Flop with Reset and Scan
 
 -  **Cell name**: sg13g2_sdfrbp_2
 -  **Type**: cell
 -  **Verilog name**: sg13g2_sdfrbp_2
 -  **Library**: sg13g2_stdcell
--  **Inputs**:  5 (D, SCD, SCE, RESET_B, CLK)
+-  **Inputs**:  5 (CLK, D, RESET_B, SCD, SCE)
 -  **Outputs**: 2 (Q, Q_N)
 
 sg13g2_sdfrbp_2 GDSII layouts

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbpq_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbpq_1.rst
@@ -1,13 +1,13 @@
 sg13g2_sdfrbpq_1
 ================
 
-**sdfrbpq**
+Posedge Single-Output Q D-Flip-Flop with Reset and Scan
 
 -  **Cell name**: sg13g2_sdfrbpq_1
 -  **Type**: cell
 -  **Verilog name**: sg13g2_sdfrbpq_1
 -  **Library**: sg13g2_stdcell
--  **Inputs**:  5 (D, SCD, SCE, RESET_B, CLK)
+-  **Inputs**:  5 (CLK, D, RESET_B, SCD, SCE)
 -  **Outputs**: 1 (Q)
 
 sg13g2_sdfrbpq_1 GDSII layouts

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbpq_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbpq_2.rst
@@ -1,13 +1,13 @@
 sg13g2_sdfrbpq_2
 ================
 
-**sdfrbpq**
+Posedge Single-Output Q D-Flip-Flop with Reset and Scan
 
 -  **Cell name**: sg13g2_sdfrbpq_2
 -  **Type**: cell
 -  **Verilog name**: sg13g2_sdfrbpq_2
 -  **Library**: sg13g2_stdcell
--  **Inputs**:  5 (D, SCD, SCE, RESET_B, CLK)
+-  **Inputs**:  5 (CLK, D, RESET_B, SCD, SCE)
 -  **Outputs**: 1 (Q)
 
 sg13g2_sdfrbpq_2 GDSII layouts

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sighold.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sighold.rst
@@ -1,7 +1,7 @@
 sg13g2_sighold
 ==============
 
-**keepstate**
+Leakage current compensator (bus holder)
 
 -  **Cell name**: sg13g2_sighold
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_slgcp_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_slgcp_1.rst
@@ -1,13 +1,13 @@
 sg13g2_slgcp_1
 ==============
 
-**sgclk**
+Scan gated clock
 
 -  **Cell name**: sg13g2_slgcp_1
 -  **Type**: cell
 -  **Verilog name**: sg13g2_slgcp_1
 -  **Library**: sg13g2_stdcell
--  **Inputs**:  3 (GATE, SCE, CLK)
+-  **Inputs**:  3 (GATE, CLK, SCE)
 -  **Outputs**: 1 (GCLK)
 
 sg13g2_slgcp_1 GDSII layouts

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_tiehi.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_tiehi.rst
@@ -1,7 +1,7 @@
 sg13g2_tiehi
 ============
 
-**tie1**
+Constant logic 0
 
 -  **Cell name**: sg13g2_tiehi
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_tielo.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_tielo.rst
@@ -1,7 +1,7 @@
 sg13g2_tielo
 ============
 
-**tie0**
+Constant logic 1
 
 -  **Cell name**: sg13g2_tielo
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_xnor2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_xnor2_1.rst
@@ -1,7 +1,7 @@
 sg13g2_xnor2_1
 ==============
 
-**xnor2_1**
+2-input XNOR
 
 -  **Cell name**: sg13g2_xnor2_1
 -  **Type**: cell

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_xor2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_xor2_1.rst
@@ -1,7 +1,7 @@
 sg13g2_xor2_1
 =============
 
-**xor2_1**
+2-input XOR
 
 -  **Cell name**: sg13g2_xor2_1
 -  **Type**: cell

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx_rtd_theme

--- a/scripts/generate_cell_docs.py
+++ b/scripts/generate_cell_docs.py
@@ -22,6 +22,13 @@ import os
 import re
 import shutil
 
+def strip_comments(text):
+    # Strip multi-line comments
+    text = re.sub(r'/\*.*?\*/', '', text, flags=re.DOTALL)
+    # Strip single-line comments
+    text = re.sub(r'//.*?\n', '\n', text)
+    return text
+
 def parse_verilog(verilog_path):
     cells = []
     if not os.path.exists(verilog_path):
@@ -31,25 +38,51 @@ def parse_verilog(verilog_path):
     with open(verilog_path, 'r') as f:
         content = f.read()
 
-    # Match modules and their preceding type comment
-    module_pattern = re.compile(r'// type:\s*(\w+)\s*.*?module\s+(\w+)\s*\((.*?)\);(.*?)\s*endmodule', re.DOTALL)
+    # Split into blocks, each ending with 'endmodule'
+    blocks = []
+    last_pos = 0
+    for match in re.finditer(r'endmodule', content):
+        blocks.append(content[last_pos:match.end()])
+        last_pos = match.end()
     
-    for match in module_pattern.finditer(content):
-        cell_type = match.group(1)
-        cell_name = match.group(2)
-        pins_str = match.group(3)
-        body = match.group(4)
+    for block in blocks:
+        # Extract module name and pins
+        mod_match = re.search(r'module\s+(\w+)\s*(?:\((.*?)\))?;', block, re.DOTALL)
+        if not mod_match:
+            continue
+
+        cell_name = mod_match.group(1)
+
+        # Extract type from comments
+        type_match = re.search(r'//\s*type\s*:\s*(\w+)', block)
+        cell_type = type_match.group(1) if type_match else "cell"
+
+        # Extract description from comments
+        desc_match = re.search(r'cell_description\s*:\s*(.*?)(?:\*|(?:\r?\n))', block)
+        description = desc_match.group(1).strip() if desc_match else ""
         
-        inputs = re.findall(r'input\s+(.*?);', body)
-        outputs = re.findall(r'output\s+(.*?);', body)
+        # Strip comments before parsing inputs/outputs
+        clean_block = strip_comments(block)
         
-        # Flatten and split by comma
-        inputs = [i.strip() for sublist in inputs for i in sublist.split(',')]
-        outputs = [o.strip() for sublist in outputs for o in sublist.split(',')]
+        # Extract inputs/outputs with more precise regex
+        # This matches 'input [wire|reg|...] PIN1, PIN2;'
+        inputs_raw = re.findall(r'^\s*input\s+(?:wire\s+|reg\s+)?(.*?);', clean_block, re.MULTILINE | re.DOTALL)
+        outputs_raw = re.findall(r'^\s*output\s+(?:wire\s+|reg\s+)?(.*?);', clean_block, re.MULTILINE | re.DOTALL)
+
+        inputs = []
+        for line in inputs_raw:
+            pins = [p.strip() for p in line.split(',')]
+            inputs.extend([p for p in pins if p])
+
+        outputs = []
+        for line in outputs_raw:
+            pins = [p.strip() for p in line.split(',')]
+            outputs.extend([p for p in pins if p])
         
         cells.append({
             'name': cell_name,
             'type': cell_type,
+            'description': description,
             'inputs': inputs,
             'outputs': outputs
         })
@@ -64,7 +97,8 @@ def generate_rst(cell, output_dir, image_relative_path):
         f.write(f"{cell['name']}\n")
         f.write("=" * len(cell['name']) + "\n\n")
         
-        f.write(f"**{cell['type']}**\n\n")
+        if cell['description']:
+            f.write(f"{cell['description']}\n\n")
         
         f.write(f"-  **Cell name**: {cell['name']}\n")
         f.write(f"-  **Type**: cell\n")
@@ -77,8 +111,6 @@ def generate_rst(cell, output_dir, image_relative_path):
         f.write("-" * (len(cell['name']) + 15) + "\n\n")
         
         image_name = f"{cell['name']}.png"
-        # Using relative path from the rst file to the _static/images directory
-        # libraries/sg13g2_stdcell/cells/ -> _static/images/
         f.write(f".. figure:: ../../../_static/images/{image_name}\n")
         f.write(f"    :align: center\n")
         f.write(f"    :width: 80%\n\n")
@@ -86,7 +118,7 @@ def generate_rst(cell, output_dir, image_relative_path):
 
 def main():
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    repo_root = os.path.abspath(os.path.join(script_dir, "../../../.."))
+    repo_root = os.path.abspath(os.path.join(script_dir, ".."))
     
     verilog_path = os.path.join(repo_root, "ihp-sg13g2/libs.ref/sg13g2_stdcell/verilog/sg13g2_stdcell.v")
     output_dir = os.path.join(repo_root, "docs/libraries/sg13g2_stdcell/cells")
@@ -99,26 +131,39 @@ def main():
     cells = parse_verilog(verilog_path)
     print(f"Found {len(cells)} cells in Verilog.")
     
-    # Ensure image destination exists
     os.makedirs(image_dst_dir, exist_ok=True)
     
     for cell in cells:
         generate_rst(cell, output_dir, None)
-        # Copy image if it exists
         image_name = f"{cell['name']}.png"
         src_image = os.path.join(image_src_dir, image_name)
         if os.path.exists(src_image):
             shutil.copy(src_image, os.path.join(image_dst_dir, image_name))
     
-    print(f"Generated {len(cells)} documentation files and copied images.")
+    print(f"Generated {len(cells)} documentation files.")
 
-    # Generate an index file
     if cells:
         with open(os.path.join(output_dir, "index.rst"), 'w') as f:
             f.write("Standard Cells\n")
             f.write("==============\n\n")
-            f.write(".. toctree::\n")
-            f.write("   :maxdepth: 1\n\n")
+
+            f.write(".. list-table:: List of cells in sg13g2_stdcell\n")
+            f.write("   :header-rows: 1\n")
+            f.write("   :widths: 20 40 10 30\n\n")
+            f.write("   * - Cell name\n")
+            f.write("     - Description\n")
+            f.write("     - Type\n")
+            f.write("     - Verilog name\n")
+
+            for cell in cells:
+                f.write(f"   * - :doc:`{cell['name']}`\n")
+                f.write(f"     - {cell['description']}\n")
+                f.write(f"     - cell\n")
+                f.write(f"     - {cell['name']}\n")
+
+            f.write("\n\n.. toctree::\n")
+            f.write("   :maxdepth: 1\n")
+            f.write("   :hidden:\n\n")
             for cell in cells:
                 f.write(f"   {cell['name']}\n")
         print("Generated index.rst")


### PR DESCRIPTION
This PR fixes the Read the Docs setup and significantly improves the standard cell documentation structure and quality. 

Key changes:
1.  **RTD Integration**: Added `.readthedocs.yaml` and `docs/requirements.txt` to enable automated builds on Read the Docs with all necessary dependencies.
2.  **Robust Tooling**: Completely refactored `scripts/generate_cell_docs.py`. The new version is much more reliable at parsing Verilog netlists. It now correctly handles comments, ensuring that descriptive text within Verilog files is not mistakenly captured as pin names. It also successfully extracts cell descriptions to populate the documentation.
3.  **Improved Documentation Style**: Updated the generated documentation to match the high-quality style of the provided `sky130-unofficial` reference. This includes a clear summary table in the cells index and human-readable descriptions on each cell's page.
4.  **Path Fixes**: Corrected the `repo_root` calculation in the generation script, allowing it to run correctly from its location in the repository.

Verified by running the generation script and performing a full `sphinx-build`. The resulting documentation is technically accurate and visually improved.

Fixes #1

---
*PR created automatically by Jules for task [2182943040530469910](https://jules.google.com/task/2182943040530469910) started by @chatelao*