### PR TITLE
Automate Read the Docs integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,11 @@ cliff*toml
 
 # OpneVAF compiled models dir
 */*/ngspice/osdi
+
+# Generated documentation artifacts
+rendered_cells/
+docs/_static/images/*.png
+docs/libraries/sg13g2_stdcell/cells/
+
+# Virtual environments
+actions_venv/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,19 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - libqt5widgets5
+    - libqt5gui5
+    - libqt5core5a
+    - libqt5svg5
+    - libqt5network5
+    - libqt5xml5
+    - libqt5printsupport5
+    - xvfb
+  jobs:
+    post_install:
+      - xvfb-run python3 scripts/render_stdcells.py
+      - python3 scripts/generate_cell_docs.py
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 sphinx_rtd_theme
+klayout

--- a/scripts/generate_cell_docs.py
+++ b/scripts/generate_cell_docs.py
@@ -22,6 +22,7 @@ import os
 import re
 import shutil
 
+
 def strip_comments(text):
     # Strip multi-line comments
     text = re.sub(r'/\*.*?\*/', '', text, flags=re.DOTALL)
@@ -29,12 +30,13 @@ def strip_comments(text):
     text = re.sub(r'//.*?\n', '\n', text)
     return text
 
+
 def parse_verilog(verilog_path):
     cells = []
     if not os.path.exists(verilog_path):
         print(f"Verilog file not found: {verilog_path}")
         return []
-        
+
     with open(verilog_path, 'r') as f:
         content = f.read()
 
@@ -44,7 +46,7 @@ def parse_verilog(verilog_path):
     for match in re.finditer(r'endmodule', content):
         blocks.append(content[last_pos:match.end()])
         last_pos = match.end()
-    
+
     for block in blocks:
         # Extract module name and pins
         mod_match = re.search(r'module\s+(\w+)\s*(?:\((.*?)\))?;', block, re.DOTALL)
@@ -60,10 +62,10 @@ def parse_verilog(verilog_path):
         # Extract description from comments
         desc_match = re.search(r'cell_description\s*:\s*(.*?)(?:\*|(?:\r?\n))', block)
         description = desc_match.group(1).strip() if desc_match else ""
-        
+
         # Strip comments before parsing inputs/outputs
         clean_block = strip_comments(block)
-        
+
         # Extract inputs/outputs with more precise regex
         # This matches 'input [wire|reg|...] PIN1, PIN2;'
         inputs_raw = re.findall(r'^\s*input\s+(?:wire\s+|reg\s+)?(.*?);', clean_block, re.MULTILINE | re.DOTALL)
@@ -78,7 +80,7 @@ def parse_verilog(verilog_path):
         for line in outputs_raw:
             pins = [p.strip() for p in line.split(',')]
             outputs.extend([p for p in pins if p])
-        
+
         cells.append({
             'name': cell_name,
             'type': cell_type,
@@ -86,60 +88,63 @@ def parse_verilog(verilog_path):
             'inputs': inputs,
             'outputs': outputs
         })
-    
+
     return cells
+
 
 def generate_rst(cell, output_dir, image_relative_path):
     os.makedirs(output_dir, exist_ok=True)
     rst_path = os.path.join(output_dir, f"{cell['name']}.rst")
-    
+
     with open(rst_path, 'w') as f:
         f.write(f"{cell['name']}\n")
         f.write("=" * len(cell['name']) + "\n\n")
-        
+
         if cell['description']:
             f.write(f"{cell['description']}\n\n")
-        
+
         f.write(f"-  **Cell name**: {cell['name']}\n")
-        f.write(f"-  **Type**: cell\n")
+        f.write("-  **Type**: cell\n")
         f.write(f"-  **Verilog name**: {cell['name']}\n")
-        f.write(f"-  **Library**: sg13g2_stdcell\n")
+        f.write("-  **Library**: sg13g2_stdcell\n")
         f.write(f"-  **Inputs**:  {len(cell['inputs'])} ({', '.join(cell['inputs'])})\n")
         f.write(f"-  **Outputs**: {len(cell['outputs'])} ({', '.join(cell['outputs'])})\n\n")
-        
+
         f.write(f"{cell['name']} GDSII layouts\n")
         f.write("-" * (len(cell['name']) + 15) + "\n\n")
-        
+
         image_name = f"{cell['name']}.png"
         f.write(f".. figure:: ../../../_static/images/{image_name}\n")
-        f.write(f"    :align: center\n")
-        f.write(f"    :width: 80%\n\n")
+        f.write("    :align: center\n")
+        f.write("    :width: 80%\n\n")
         f.write(f"    {cell['name']}\n")
+
 
 def main():
     script_dir = os.path.dirname(os.path.abspath(__file__))
     repo_root = os.path.abspath(os.path.join(script_dir, ".."))
-    
+
     verilog_path = os.path.join(repo_root, "ihp-sg13g2/libs.ref/sg13g2_stdcell/verilog/sg13g2_stdcell.v")
     output_dir = os.path.join(repo_root, "docs/libraries/sg13g2_stdcell/cells")
     image_src_dir = os.path.join(repo_root, "rendered_cells")
     image_dst_dir = os.path.join(repo_root, "docs/_static/images")
-    
+
     print(f"Verilog path: {verilog_path}")
     print(f"Output directory: {output_dir}")
-    
+
     cells = parse_verilog(verilog_path)
     print(f"Found {len(cells)} cells in Verilog.")
-    
+
     os.makedirs(image_dst_dir, exist_ok=True)
-    
+    os.makedirs(output_dir, exist_ok=True)
+
     for cell in cells:
         generate_rst(cell, output_dir, None)
         image_name = f"{cell['name']}.png"
         src_image = os.path.join(image_src_dir, image_name)
         if os.path.exists(src_image):
             shutil.copy(src_image, os.path.join(image_dst_dir, image_name))
-    
+
     print(f"Generated {len(cells)} documentation files.")
 
     if cells:
@@ -158,7 +163,7 @@ def main():
             for cell in cells:
                 f.write(f"   * - :doc:`{cell['name']}`\n")
                 f.write(f"     - {cell['description']}\n")
-                f.write(f"     - cell\n")
+                f.write("     - cell\n")
                 f.write(f"     - {cell['name']}\n")
 
             f.write("\n\n.. toctree::\n")
@@ -167,6 +172,7 @@ def main():
             for cell in cells:
                 f.write(f"   {cell['name']}\n")
         print("Generated index.rst")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/render_stdcells.py
+++ b/scripts/render_stdcells.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import os
+import pya
+
+
+def render_cells():
+    # Setup paths
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    repo_root = os.path.abspath(os.path.join(script_dir, ".."))
+    gds_path = os.path.join(repo_root, "ihp-sg13g2/libs.ref/sg13g2_stdcell/gds/sg13g2_stdcell.gds")
+    lyp_path = os.path.join(repo_root, "ihp-sg13g2/libs.tech/klayout/tech/sg13g2.lyp")
+    output_dir = os.path.join(repo_root, "rendered_cells")
+
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    # Create a layout and load the GDS
+    layout = pya.Layout()
+    layout.read(gds_path)
+
+    # Create a LayoutView
+    # In headless mode, this requires xvfb-run
+    view = pya.LayoutView()
+    view.show_layout(layout, False)
+
+    if os.path.exists(lyp_path):
+        view.load_layer_props(lyp_path)
+    else:
+        print(f"Warning: Layer properties file not found at {lyp_path}")
+
+    # Get all top cells
+    top_cells = layout.top_cells()
+
+    print(f"Found {len(top_cells)} top cells. Rendering...")
+
+    for cell in top_cells:
+        cell_name = cell.name
+        print(f"Rendering {cell_name}...")
+
+        # Select the cell
+        view.select_cell(cell.cell_index(), 0)
+        view.zoom_fit()
+
+        # Save image
+        image_path = os.path.join(output_dir, f"{cell_name}.png")
+        view.save_image(image_path, 800, 600)
+
+    print("Rendering complete.")
+
+
+if __name__ == "__main__":
+    render_cells()


### PR DESCRIPTION
I have automated the documentation generation for standard cells to ensure successful integration with Read the Docs. This involved creating a new script to render cell layouts into images, updating the Sphinx documentation generation script, and configuring the `.readthedocs.yaml` file to handle these steps and their system dependencies automatically during the build process. I also updated the project's `.gitignore` and dependency files to reflect these changes. The entire process was verified with a successful local build.

Fixes #3

---
*PR created automatically by Jules for task [4247162437938779812](https://jules.google.com/task/4247162437938779812) started by @chatelao*