### PR TITLE
Implement algorithmic schematic SVG generation

### DIFF
--- a/docs/_static/schematics/sg13g2_a21o_1.svg
+++ b/docs/_static/schematics/sg13g2_a21o_1.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="249" height="129">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_a21o_1.v:38$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_a21o_1.v:38$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_a21o_1.v:39$2">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_a21o_1.v:39$2"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_a21o_1.v:39$2"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(207,37)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A1">
+    <text x="15" y="-4" class="nodelabel cell_A1" s:attribute="ref">A1</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A1"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_A2">
+    <text x="15" y="-4" class="nodelabel cell_A2" s:attribute="ref">A2</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A2"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_B1">
+    <text x="15" y="-4" class="nodelabel cell_B1" s:attribute="ref">B1</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B1"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="77" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="145" y1="39.5" y2="39.5" class="net_6"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="145" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="172" x2="207" y1="47" y2="47" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_a21o_2.svg
+++ b/docs/_static/schematics/sg13g2_a21o_2.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="249" height="129">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_a21o_2.v:28$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_a21o_2.v:28$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_a21o_2.v:29$2">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_a21o_2.v:29$2"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_a21o_2.v:29$2"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(207,37)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A1">
+    <text x="15" y="-4" class="nodelabel cell_A1" s:attribute="ref">A1</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A1"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_A2">
+    <text x="15" y="-4" class="nodelabel cell_A2" s:attribute="ref">A2</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A2"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_B1">
+    <text x="15" y="-4" class="nodelabel cell_B1" s:attribute="ref">B1</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B1"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="77" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="145" y1="39.5" y2="39.5" class="net_6"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="145" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="172" x2="207" y1="47" y2="47" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_a21oi_1.svg
+++ b/docs/_static/schematics/sg13g2_a21oi_1.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="314" height="129">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_a21oi_1.v:28$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_a21oi_1.v:28$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(207,37)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_a21oi_1.v:0$3">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_a21oi_1.v:0$3"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_a21oi_1.v:0$3"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_a21oi_1.v:29$2">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_a21oi_1.v:29$2"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_a21oi_1.v:29$2"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(272,37)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A1">
+    <text x="15" y="-4" class="nodelabel cell_A1" s:attribute="ref">A1</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A1"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_A2">
+    <text x="15" y="-4" class="nodelabel cell_A2" s:attribute="ref">A2</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A2"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_B1">
+    <text x="15" y="-4" class="nodelabel cell_B1" s:attribute="ref">B1</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B1"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="77" y1="47" y2="47" class="net_4"/>
+  <line x1="172" x2="207" y1="47" y2="47" class="net_7"/>
+  <line x1="107" x2="145" y1="39.5" y2="39.5" class="net_6"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="145" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="232" x2="272" y1="47" y2="47" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_a21oi_2.svg
+++ b/docs/_static/schematics/sg13g2_a21oi_2.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="314" height="129">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_a21oi_2.v:28$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_a21oi_2.v:28$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(207,37)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_a21oi_2.v:0$3">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_a21oi_2.v:0$3"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_a21oi_2.v:0$3"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_a21oi_2.v:29$2">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_a21oi_2.v:29$2"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_a21oi_2.v:29$2"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(272,37)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A1">
+    <text x="15" y="-4" class="nodelabel cell_A1" s:attribute="ref">A1</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A1"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_A2">
+    <text x="15" y="-4" class="nodelabel cell_A2" s:attribute="ref">A2</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A2"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_B1">
+    <text x="15" y="-4" class="nodelabel cell_B1" s:attribute="ref">B1</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B1"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="77" y1="47" y2="47" class="net_4"/>
+  <line x1="172" x2="207" y1="47" y2="47" class="net_7"/>
+  <line x1="107" x2="145" y1="39.5" y2="39.5" class="net_6"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="145" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="232" x2="272" y1="47" y2="47" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_a221oi_1.svg
+++ b/docs/_static/schematics/sg13g2_a221oi_1.svg
@@ -1,0 +1,123 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="379" height="249">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(77,157)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_a221oi_1.v:28$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_a221oi_1.v:28$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="and" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_a221oi_1.v:29$2">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_a221oi_1.v:29$2"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(272,44.5)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_a221oi_1.v:0$5">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_a221oi_1.v:0$5"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_a221oi_1.v:0$5"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_a221oi_1.v:30$3">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_a221oi_1.v:30$3"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_a221oi_1.v:30$3"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(207,42)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_a221oi_1.v:30$4">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_a221oi_1.v:30$4"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_a221oi_1.v:30$4"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(337,44.5)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A1">
+    <text x="15" y="-4" class="nodelabel cell_A1" s:attribute="ref">A1</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A1"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_A2">
+    <text x="15" y="-4" class="nodelabel cell_A2" s:attribute="ref">A2</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A2"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,152)" s:width="30" s:height="20" id="cell_B1">
+    <text x="15" y="-4" class="nodelabel cell_B1" s:attribute="ref">B1</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B1"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,217)" s:width="30" s:height="20" id="cell_B2">
+    <text x="15" y="-4" class="nodelabel cell_B2" s:attribute="ref">B2</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B2"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(142,104.5)" s:width="30" s:height="20" id="cell_C1">
+    <text x="15" y="-4" class="nodelabel cell_C1" s:attribute="ref">C1</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_C1"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="162" y2="162" class="net_5"/>
+  <line x1="40" x2="52" y1="227" y2="227" class="net_6"/>
+  <line x1="52" x2="52" y1="227" y2="177" class="net_6"/>
+  <line x1="52" x2="77" y1="177" y2="177" class="net_6"/>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="77" y1="47" y2="47" class="net_4"/>
+  <line x1="237" x2="272" y1="54.5" y2="54.5" class="net_10"/>
+  <line x1="107" x2="145" y1="39.5" y2="39.5" class="net_9"/>
+  <line x1="107" x2="117" y1="169.5" y2="169.5" class="net_8"/>
+  <line x1="117" x2="117" y1="169.5" y2="54.5" class="net_8"/>
+  <line x1="117" x2="145" y1="54.5" y2="54.5" class="net_8"/>
+  <line x1="172" x2="210" y1="47" y2="47" class="net_11"/>
+  <line x1="170" x2="182" y1="114.5" y2="114.5" class="net_7"/>
+  <line x1="182" x2="182" y1="114.5" y2="62" class="net_7"/>
+  <line x1="182" x2="210" y1="62" y2="62" class="net_7"/>
+  <line x1="297" x2="337" y1="54.5" y2="54.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_a22oi_1.svg
+++ b/docs/_static/schematics/sg13g2_a22oi_1.svg
@@ -1,0 +1,103 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="314" height="249">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(77,157)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_a22oi_1.v:28$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_a22oi_1.v:28$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="and" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_a22oi_1.v:29$2">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_a22oi_1.v:29$2"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(207,37)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_a22oi_1.v:0$4">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_a22oi_1.v:0$4"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_a22oi_1.v:0$4"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_a22oi_1.v:30$3">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_a22oi_1.v:30$3"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_a22oi_1.v:30$3"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(272,37)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A1">
+    <text x="15" y="-4" class="nodelabel cell_A1" s:attribute="ref">A1</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A1"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_A2">
+    <text x="15" y="-4" class="nodelabel cell_A2" s:attribute="ref">A2</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A2"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,152)" s:width="30" s:height="20" id="cell_B1">
+    <text x="15" y="-4" class="nodelabel cell_B1" s:attribute="ref">B1</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B1"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,217)" s:width="30" s:height="20" id="cell_B2">
+    <text x="15" y="-4" class="nodelabel cell_B2" s:attribute="ref">B2</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B2"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="162" y2="162" class="net_5"/>
+  <line x1="40" x2="52" y1="227" y2="227" class="net_6"/>
+  <line x1="52" x2="52" y1="227" y2="177" class="net_6"/>
+  <line x1="52" x2="77" y1="177" y2="177" class="net_6"/>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="77" y1="47" y2="47" class="net_4"/>
+  <line x1="172" x2="207" y1="47" y2="47" class="net_9"/>
+  <line x1="107" x2="145" y1="39.5" y2="39.5" class="net_8"/>
+  <line x1="107" x2="117" y1="169.5" y2="169.5" class="net_7"/>
+  <line x1="117" x2="117" y1="169.5" y2="54.5" class="net_7"/>
+  <line x1="117" x2="145" y1="54.5" y2="54.5" class="net_7"/>
+  <line x1="232" x2="272" y1="47" y2="47" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_and2_1.svg
+++ b/docs/_static/schematics/sg13g2_and2_1.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="184" height="119">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_and2_1.v:26$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_and2_1.v:26$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(142,29.5)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="77" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="142" y1="39.5" y2="39.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_and2_2.svg
+++ b/docs/_static/schematics/sg13g2_and2_2.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="184" height="119">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_and2_2.v:26$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_and2_2.v:26$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(142,29.5)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="77" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="142" y1="39.5" y2="39.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_and3_1.svg
+++ b/docs/_static/schematics/sg13g2_and3_1.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="249" height="129">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_and3_1.v:26$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_and3_1.v:26$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="and" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_and3_1.v:26$2">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_and3_1.v:26$2"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(207,37)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_C">
+    <text x="15" y="-4" class="nodelabel cell_C" s:attribute="ref">C</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_C"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="77" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="142" y1="39.5" y2="39.5" class="net_6"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="142" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="172" x2="207" y1="47" y2="47" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_and3_2.svg
+++ b/docs/_static/schematics/sg13g2_and3_2.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="249" height="129">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_and3_2.v:26$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_and3_2.v:26$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="and" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_and3_2.v:26$2">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_and3_2.v:26$2"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(207,37)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_C">
+    <text x="15" y="-4" class="nodelabel cell_C" s:attribute="ref">C</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_C"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="77" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="142" y1="39.5" y2="39.5" class="net_6"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="142" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="172" x2="207" y1="47" y2="47" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_and4_1.svg
+++ b/docs/_static/schematics/sg13g2_and4_1.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="314" height="136.5">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_and4_1.v:26$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_and4_1.v:26$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="and" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_and4_1.v:26$2">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_and4_1.v:26$2"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="and" transform="translate(207,42)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_and4_1.v:26$3">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_and4_1.v:26$3"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(272,44.5)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_C">
+    <text x="15" y="-4" class="nodelabel cell_C" s:attribute="ref">C</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_C"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(142,104.5)" s:width="30" s:height="20" id="cell_D">
+    <text x="15" y="-4" class="nodelabel cell_D" s:attribute="ref">D</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_D"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="77" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="142" y1="39.5" y2="39.5" class="net_7"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="142" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="172" x2="207" y1="47" y2="47" class="net_8"/>
+  <line x1="170" x2="182" y1="114.5" y2="114.5" class="net_6"/>
+  <line x1="182" x2="182" y1="114.5" y2="62" class="net_6"/>
+  <line x1="182" x2="207" y1="62" y2="62" class="net_6"/>
+  <line x1="237" x2="272" y1="54.5" y2="54.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_and4_2.svg
+++ b/docs/_static/schematics/sg13g2_and4_2.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="314" height="136.5">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_and4_2.v:26$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_and4_2.v:26$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="and" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_and4_2.v:26$2">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_and4_2.v:26$2"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="and" transform="translate(207,42)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_and4_2.v:26$3">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_and4_2.v:26$3"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(272,44.5)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_C">
+    <text x="15" y="-4" class="nodelabel cell_C" s:attribute="ref">C</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_C"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(142,104.5)" s:width="30" s:height="20" id="cell_D">
+    <text x="15" y="-4" class="nodelabel cell_D" s:attribute="ref">D</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_D"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="77" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="142" y1="39.5" y2="39.5" class="net_7"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="142" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="172" x2="207" y1="47" y2="47" class="net_8"/>
+  <line x1="170" x2="182" y1="114.5" y2="114.5" class="net_6"/>
+  <line x1="182" x2="182" y1="114.5" y2="62" class="net_6"/>
+  <line x1="182" x2="207" y1="62" y2="62" class="net_6"/>
+  <line x1="237" x2="272" y1="54.5" y2="54.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_antennanp.svg
+++ b/docs/_static/schematics/sg13g2_antennanp.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="54" height="54">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+</svg>

--- a/docs/_static/schematics/sg13g2_buf_1.svg
+++ b/docs/_static/schematics/sg13g2_buf_1.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="119" height="54">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="outputExt" transform="translate(77,22)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_buf_16.svg
+++ b/docs/_static/schematics/sg13g2_buf_16.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="119" height="54">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="outputExt" transform="translate(77,22)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_buf_2.svg
+++ b/docs/_static/schematics/sg13g2_buf_2.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="119" height="54">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="outputExt" transform="translate(77,22)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_buf_4.svg
+++ b/docs/_static/schematics/sg13g2_buf_4.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="119" height="54">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="outputExt" transform="translate(77,22)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_buf_8.svg
+++ b/docs/_static/schematics/sg13g2_buf_8.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="119" height="54">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="outputExt" transform="translate(77,22)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_dlygate4sd1_1.svg
+++ b/docs/_static/schematics/sg13g2_dlygate4sd1_1.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="119" height="54">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="outputExt" transform="translate(77,22)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_dlygate4sd2_1.svg
+++ b/docs/_static/schematics/sg13g2_dlygate4sd2_1.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="119" height="54">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="outputExt" transform="translate(77,22)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_dlygate4sd3_1.svg
+++ b/docs/_static/schematics/sg13g2_dlygate4sd3_1.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="119" height="54">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="outputExt" transform="translate(77,22)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_inv_1.svg
+++ b/docs/_static/schematics/sg13g2_inv_1.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="184" height="54">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="not" transform="translate(77,22)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_inv_1.v:0$1">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_inv_1.v:0$1"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_inv_1.v:0$1"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(142,22)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="102" x2="142" y1="32" y2="32" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_inv_16.svg
+++ b/docs/_static/schematics/sg13g2_inv_16.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="184" height="54">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="not" transform="translate(77,22)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_inv_16.v:0$1">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_inv_16.v:0$1"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_inv_16.v:0$1"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(142,22)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="102" x2="142" y1="32" y2="32" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_inv_2.svg
+++ b/docs/_static/schematics/sg13g2_inv_2.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="184" height="54">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="not" transform="translate(77,22)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_inv_2.v:0$1">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_inv_2.v:0$1"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_inv_2.v:0$1"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(142,22)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="102" x2="142" y1="32" y2="32" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_inv_4.svg
+++ b/docs/_static/schematics/sg13g2_inv_4.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="184" height="54">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="not" transform="translate(77,22)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_inv_4.v:0$1">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_inv_4.v:0$1"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_inv_4.v:0$1"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(142,22)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="102" x2="142" y1="32" y2="32" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_inv_8.svg
+++ b/docs/_static/schematics/sg13g2_inv_8.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="184" height="54">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="not" transform="translate(77,22)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_inv_8.v:0$1">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_inv_8.v:0$1"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_inv_8.v:0$1"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(142,22)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="102" x2="142" y1="32" y2="32" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_nand2_1.svg
+++ b/docs/_static/schematics/sg13g2_nand2_1.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="249" height="119">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_nand2_1.v:29$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_nand2_1.v:29$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(142,29.5)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nand2_1.v:0$2">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nand2_1.v:0$2"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nand2_1.v:0$2"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(207,29.5)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="77" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="142" y1="39.5" y2="39.5" class="net_5"/>
+  <line x1="167" x2="207" y1="39.5" y2="39.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_nand2_2.svg
+++ b/docs/_static/schematics/sg13g2_nand2_2.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="249" height="119">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_nand2_2.v:29$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_nand2_2.v:29$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(142,29.5)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nand2_2.v:0$2">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nand2_2.v:0$2"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nand2_2.v:0$2"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(207,29.5)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="77" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="142" y1="39.5" y2="39.5" class="net_5"/>
+  <line x1="167" x2="207" y1="39.5" y2="39.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_nand2b_1.svg
+++ b/docs/_static/schematics/sg13g2_nand2b_1.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="314" height="119">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(142,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_nand2b_1.v:30$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_nand2b_1.v:30$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(77,22)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nand2b_1.v:0$2">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nand2b_1.v:0$2"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nand2b_1.v:0$2"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(207,29.5)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nand2b_1.v:0$3">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nand2b_1.v:0$3"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nand2b_1.v:0$3"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(272,29.5)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A_N">
+    <text x="15" y="-4" class="nodelabel cell_A_N" s:attribute="ref">A_N</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A_N"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="102" x2="142" y1="32" y2="32" class="net_5"/>
+  <line x1="105" x2="117" y1="97" y2="97" class="net_4"/>
+  <line x1="117" x2="117" y1="97" y2="47" class="net_4"/>
+  <line x1="117" x2="142" y1="47" y2="47" class="net_4"/>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="172" x2="207" y1="39.5" y2="39.5" class="net_6"/>
+  <line x1="232" x2="272" y1="39.5" y2="39.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_nand2b_2.svg
+++ b/docs/_static/schematics/sg13g2_nand2b_2.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="314" height="119">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(142,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_nand2b_2.v:30$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_nand2b_2.v:30$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(77,22)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nand2b_2.v:0$2">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nand2b_2.v:0$2"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nand2b_2.v:0$2"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(207,29.5)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nand2b_2.v:0$3">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nand2b_2.v:0$3"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nand2b_2.v:0$3"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(272,29.5)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A_N">
+    <text x="15" y="-4" class="nodelabel cell_A_N" s:attribute="ref">A_N</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A_N"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="102" x2="142" y1="32" y2="32" class="net_5"/>
+  <line x1="105" x2="117" y1="97" y2="97" class="net_4"/>
+  <line x1="117" x2="117" y1="97" y2="47" class="net_4"/>
+  <line x1="117" x2="142" y1="47" y2="47" class="net_4"/>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="172" x2="207" y1="39.5" y2="39.5" class="net_6"/>
+  <line x1="232" x2="272" y1="39.5" y2="39.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_nand3_1.svg
+++ b/docs/_static/schematics/sg13g2_nand3_1.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="314" height="129">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_nand3_1.v:29$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_nand3_1.v:29$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="and" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_nand3_1.v:29$2">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_nand3_1.v:29$2"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(207,37)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nand3_1.v:0$3">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nand3_1.v:0$3"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nand3_1.v:0$3"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(272,37)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_C">
+    <text x="15" y="-4" class="nodelabel cell_C" s:attribute="ref">C</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_C"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="77" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="142" y1="39.5" y2="39.5" class="net_6"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="142" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="172" x2="207" y1="47" y2="47" class="net_7"/>
+  <line x1="232" x2="272" y1="47" y2="47" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_nand3b_1.svg
+++ b/docs/_static/schematics/sg13g2_nand3b_1.svg
@@ -1,0 +1,93 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="379" height="129">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(142,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_nand3b_1.v:30$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_nand3b_1.v:30$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="and" transform="translate(207,34.5)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_nand3b_1.v:30$2">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_nand3b_1.v:30$2"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(77,22)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nand3b_1.v:0$3">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nand3b_1.v:0$3"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nand3b_1.v:0$3"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(272,37)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nand3b_1.v:0$4">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nand3b_1.v:0$4"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nand3b_1.v:0$4"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(337,37)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A_N">
+    <text x="15" y="-4" class="nodelabel cell_A_N" s:attribute="ref">A_N</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A_N"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(142,97)" s:width="30" s:height="20" id="cell_C">
+    <text x="15" y="-4" class="nodelabel cell_C" s:attribute="ref">C</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_C"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="102" x2="142" y1="32" y2="32" class="net_6"/>
+  <line x1="105" x2="117" y1="97" y2="97" class="net_4"/>
+  <line x1="117" x2="117" y1="97" y2="47" class="net_4"/>
+  <line x1="117" x2="142" y1="47" y2="47" class="net_4"/>
+  <line x1="172" x2="207" y1="39.5" y2="39.5" class="net_7"/>
+  <line x1="170" x2="182" y1="107" y2="107" class="net_5"/>
+  <line x1="182" x2="182" y1="107" y2="54.5" class="net_5"/>
+  <line x1="182" x2="207" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="237" x2="272" y1="47" y2="47" class="net_8"/>
+  <line x1="297" x2="337" y1="47" y2="47" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_nand4_1.svg
+++ b/docs/_static/schematics/sg13g2_nand4_1.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="379" height="136.5">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_nand4_1.v:29$1">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_nand4_1.v:29$1"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="and" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_nand4_1.v:29$2">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_nand4_1.v:29$2"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="and" transform="translate(207,42)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_nand4_1.v:29$3">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_nand4_1.v:29$3"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(272,44.5)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nand4_1.v:0$4">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nand4_1.v:0$4"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nand4_1.v:0$4"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(337,44.5)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_C">
+    <text x="15" y="-4" class="nodelabel cell_C" s:attribute="ref">C</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_C"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(142,104.5)" s:width="30" s:height="20" id="cell_D">
+    <text x="15" y="-4" class="nodelabel cell_D" s:attribute="ref">D</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_D"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="77" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="142" y1="39.5" y2="39.5" class="net_7"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="142" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="172" x2="207" y1="47" y2="47" class="net_8"/>
+  <line x1="170" x2="182" y1="114.5" y2="114.5" class="net_6"/>
+  <line x1="182" x2="182" y1="114.5" y2="62" class="net_6"/>
+  <line x1="182" x2="207" y1="62" y2="62" class="net_6"/>
+  <line x1="237" x2="272" y1="54.5" y2="54.5" class="net_9"/>
+  <line x1="297" x2="337" y1="54.5" y2="54.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_nor2_1.svg
+++ b/docs/_static/schematics/sg13g2_nor2_1.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="249" height="119">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="not" transform="translate(142,29.5)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nor2_1.v:0$2">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nor2_1.v:0$2"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nor2_1.v:0$2"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_nor2_1.v:29$1">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_nor2_1.v:29$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_nor2_1.v:29$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(207,29.5)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="107" x2="142" y1="39.5" y2="39.5" class="net_5"/>
+  <line x1="40" x2="80" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="80" y1="47" y2="47" class="net_4"/>
+  <line x1="167" x2="207" y1="39.5" y2="39.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_nor2_2.svg
+++ b/docs/_static/schematics/sg13g2_nor2_2.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="249" height="119">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="not" transform="translate(142,29.5)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nor2_2.v:0$2">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nor2_2.v:0$2"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nor2_2.v:0$2"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_nor2_2.v:29$1">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_nor2_2.v:29$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_nor2_2.v:29$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(207,29.5)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="107" x2="142" y1="39.5" y2="39.5" class="net_5"/>
+  <line x1="40" x2="80" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="80" y1="47" y2="47" class="net_4"/>
+  <line x1="167" x2="207" y1="39.5" y2="39.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_nor2b_1.svg
+++ b/docs/_static/schematics/sg13g2_nor2b_1.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="314" height="109">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="not" transform="translate(77,77)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nor2b_1.v:0$2">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nor2b_1.v:0$2"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nor2b_1.v:0$2"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(207,29.5)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nor2b_1.v:0$3">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nor2b_1.v:0$3"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nor2b_1.v:0$3"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(142,27)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_nor2b_1.v:30$1">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_nor2b_1.v:30$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_nor2b_1.v:30$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(272,29.5)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,77)" s:width="30" s:height="20" id="cell_B_N">
+    <text x="15" y="-4" class="nodelabel cell_B_N" s:attribute="ref">B_N</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B_N"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="87" y2="87" class="net_4"/>
+  <line x1="172" x2="207" y1="39.5" y2="39.5" class="net_6"/>
+  <line x1="105" x2="145" y1="32" y2="32" class="net_3"/>
+  <line x1="102" x2="117" y1="87" y2="87" class="net_5"/>
+  <line x1="117" x2="117" y1="87" y2="47" class="net_5"/>
+  <line x1="117" x2="145" y1="47" y2="47" class="net_5"/>
+  <line x1="232" x2="272" y1="39.5" y2="39.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_nor2b_2.svg
+++ b/docs/_static/schematics/sg13g2_nor2b_2.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="314" height="109">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="not" transform="translate(77,77)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nor2b_2.v:0$2">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nor2b_2.v:0$2"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nor2b_2.v:0$2"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(207,29.5)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nor2b_2.v:0$3">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nor2b_2.v:0$3"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nor2b_2.v:0$3"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(142,27)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_nor2b_2.v:30$1">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_nor2b_2.v:30$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_nor2b_2.v:30$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(272,29.5)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,77)" s:width="30" s:height="20" id="cell_B_N">
+    <text x="15" y="-4" class="nodelabel cell_B_N" s:attribute="ref">B_N</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B_N"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="77" y1="87" y2="87" class="net_4"/>
+  <line x1="172" x2="207" y1="39.5" y2="39.5" class="net_6"/>
+  <line x1="105" x2="145" y1="32" y2="32" class="net_3"/>
+  <line x1="102" x2="117" y1="87" y2="87" class="net_5"/>
+  <line x1="117" x2="117" y1="87" y2="47" class="net_5"/>
+  <line x1="117" x2="145" y1="47" y2="47" class="net_5"/>
+  <line x1="232" x2="272" y1="39.5" y2="39.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_nor3_1.svg
+++ b/docs/_static/schematics/sg13g2_nor3_1.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="314" height="129">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="not" transform="translate(207,37)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nor3_1.v:0$3">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nor3_1.v:0$3"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nor3_1.v:0$3"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_nor3_1.v:29$1">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_nor3_1.v:29$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_nor3_1.v:29$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_nor3_1.v:29$2">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_nor3_1.v:29$2"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_nor3_1.v:29$2"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(272,37)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_C">
+    <text x="15" y="-4" class="nodelabel cell_C" s:attribute="ref">C</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_C"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="172" x2="207" y1="47" y2="47" class="net_6"/>
+  <line x1="40" x2="80" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="80" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="145" y1="39.5" y2="39.5" class="net_7"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="145" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="232" x2="272" y1="47" y2="47" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_nor3_2.svg
+++ b/docs/_static/schematics/sg13g2_nor3_2.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="314" height="129">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="not" transform="translate(207,37)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nor3_2.v:0$3">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nor3_2.v:0$3"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nor3_2.v:0$3"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_nor3_2.v:29$1">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_nor3_2.v:29$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_nor3_2.v:29$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_nor3_2.v:29$2">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_nor3_2.v:29$2"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_nor3_2.v:29$2"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(272,37)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_C">
+    <text x="15" y="-4" class="nodelabel cell_C" s:attribute="ref">C</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_C"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="172" x2="207" y1="47" y2="47" class="net_6"/>
+  <line x1="40" x2="80" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="80" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="145" y1="39.5" y2="39.5" class="net_7"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="145" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="232" x2="272" y1="47" y2="47" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_nor4_1.svg
+++ b/docs/_static/schematics/sg13g2_nor4_1.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="379" height="136.5">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="not" transform="translate(272,44.5)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nor4_1.v:0$4">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nor4_1.v:0$4"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nor4_1.v:0$4"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_nor4_1.v:29$1">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_nor4_1.v:29$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_nor4_1.v:29$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_nor4_1.v:29$2">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_nor4_1.v:29$2"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_nor4_1.v:29$2"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(207,42)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_nor4_1.v:29$3">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_nor4_1.v:29$3"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_nor4_1.v:29$3"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(337,44.5)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_C">
+    <text x="15" y="-4" class="nodelabel cell_C" s:attribute="ref">C</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_C"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(142,104.5)" s:width="30" s:height="20" id="cell_D">
+    <text x="15" y="-4" class="nodelabel cell_D" s:attribute="ref">D</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_D"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="237" x2="272" y1="54.5" y2="54.5" class="net_7"/>
+  <line x1="40" x2="80" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="80" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="145" y1="39.5" y2="39.5" class="net_8"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="145" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="172" x2="210" y1="47" y2="47" class="net_9"/>
+  <line x1="170" x2="182" y1="114.5" y2="114.5" class="net_6"/>
+  <line x1="182" x2="182" y1="114.5" y2="62" class="net_6"/>
+  <line x1="182" x2="210" y1="62" y2="62" class="net_6"/>
+  <line x1="297" x2="337" y1="54.5" y2="54.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_nor4_2.svg
+++ b/docs/_static/schematics/sg13g2_nor4_2.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="379" height="136.5">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="not" transform="translate(272,44.5)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_nor4_2.v:0$4">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_nor4_2.v:0$4"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_nor4_2.v:0$4"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_nor4_2.v:29$1">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_nor4_2.v:29$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_nor4_2.v:29$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_nor4_2.v:29$2">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_nor4_2.v:29$2"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_nor4_2.v:29$2"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(207,42)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_nor4_2.v:29$3">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_nor4_2.v:29$3"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_nor4_2.v:29$3"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(337,44.5)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_C">
+    <text x="15" y="-4" class="nodelabel cell_C" s:attribute="ref">C</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_C"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(142,104.5)" s:width="30" s:height="20" id="cell_D">
+    <text x="15" y="-4" class="nodelabel cell_D" s:attribute="ref">D</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_D"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="237" x2="272" y1="54.5" y2="54.5" class="net_7"/>
+  <line x1="40" x2="80" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="80" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="145" y1="39.5" y2="39.5" class="net_8"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="145" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="172" x2="210" y1="47" y2="47" class="net_9"/>
+  <line x1="170" x2="182" y1="114.5" y2="114.5" class="net_6"/>
+  <line x1="182" x2="182" y1="114.5" y2="62" class="net_6"/>
+  <line x1="182" x2="210" y1="62" y2="62" class="net_6"/>
+  <line x1="297" x2="337" y1="54.5" y2="54.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_o21ai_1.svg
+++ b/docs/_static/schematics/sg13g2_o21ai_1.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="314" height="129">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="and" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$and$/app/temp_json/sg13g2_o21ai_1.v:30$2">
+    <s:alias val="$and"/>
+    <s:alias val="$logic_and"/>
+    <s:alias val="$_AND_"/>
+    <path d="M0,0 L0,25 L15,25 A15 12.5 0 0 0 15,0 Z" class="cell_$and$/app/temp_json/sg13g2_o21ai_1.v:30$2"/>
+    <g s:x="0" s:y="5" s:pid="A"/>
+    <g s:x="0" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="not" transform="translate(207,37)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_o21ai_1.v:0$3">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_o21ai_1.v:0$3"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_o21ai_1.v:0$3"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_o21ai_1.v:29$1">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_o21ai_1.v:29$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_o21ai_1.v:29$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(272,37)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A1">
+    <text x="15" y="-4" class="nodelabel cell_A1" s:attribute="ref">A1</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A1"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_A2">
+    <text x="15" y="-4" class="nodelabel cell_A2" s:attribute="ref">A2</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A2"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_B1">
+    <text x="15" y="-4" class="nodelabel cell_B1" s:attribute="ref">B1</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B1"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="107" x2="142" y1="39.5" y2="39.5" class="net_6"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="142" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="172" x2="207" y1="47" y2="47" class="net_7"/>
+  <line x1="40" x2="80" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="80" y1="47" y2="47" class="net_4"/>
+  <line x1="232" x2="272" y1="47" y2="47" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_or2_1.svg
+++ b/docs/_static/schematics/sg13g2_or2_1.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="184" height="119">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="or" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_or2_1.v:27$1">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_or2_1.v:27$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_or2_1.v:27$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(142,29.5)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="80" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="80" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="142" y1="39.5" y2="39.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_or2_2.svg
+++ b/docs/_static/schematics/sg13g2_or2_2.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="184" height="119">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="or" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_or2_2.v:27$1">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_or2_2.v:27$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_or2_2.v:27$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(142,29.5)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="80" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="80" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="142" y1="39.5" y2="39.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_or3_1.svg
+++ b/docs/_static/schematics/sg13g2_or3_1.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="249" height="129">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="or" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_or3_1.v:27$1">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_or3_1.v:27$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_or3_1.v:27$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_or3_1.v:27$2">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_or3_1.v:27$2"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_or3_1.v:27$2"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(207,37)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_C">
+    <text x="15" y="-4" class="nodelabel cell_C" s:attribute="ref">C</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_C"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="80" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="80" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="145" y1="39.5" y2="39.5" class="net_6"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="145" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="172" x2="207" y1="47" y2="47" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_or3_2.svg
+++ b/docs/_static/schematics/sg13g2_or3_2.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="249" height="129">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="or" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_or3_2.v:27$1">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_or3_2.v:27$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_or3_2.v:27$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_or3_2.v:27$2">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_or3_2.v:27$2"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_or3_2.v:27$2"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(207,37)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_C">
+    <text x="15" y="-4" class="nodelabel cell_C" s:attribute="ref">C</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_C"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="80" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="80" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="145" y1="39.5" y2="39.5" class="net_6"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="145" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="172" x2="207" y1="47" y2="47" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_or4_1.svg
+++ b/docs/_static/schematics/sg13g2_or4_1.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="314" height="136.5">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="or" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_or4_1.v:27$1">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_or4_1.v:27$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_or4_1.v:27$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_or4_1.v:27$2">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_or4_1.v:27$2"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_or4_1.v:27$2"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(207,42)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_or4_1.v:27$3">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_or4_1.v:27$3"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_or4_1.v:27$3"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(272,44.5)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_C">
+    <text x="15" y="-4" class="nodelabel cell_C" s:attribute="ref">C</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_C"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(142,104.5)" s:width="30" s:height="20" id="cell_D">
+    <text x="15" y="-4" class="nodelabel cell_D" s:attribute="ref">D</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_D"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="80" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="80" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="145" y1="39.5" y2="39.5" class="net_7"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="145" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="172" x2="210" y1="47" y2="47" class="net_8"/>
+  <line x1="170" x2="182" y1="114.5" y2="114.5" class="net_6"/>
+  <line x1="182" x2="182" y1="114.5" y2="62" class="net_6"/>
+  <line x1="182" x2="210" y1="62" y2="62" class="net_6"/>
+  <line x1="237" x2="272" y1="54.5" y2="54.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_or4_2.svg
+++ b/docs/_static/schematics/sg13g2_or4_2.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="314" height="136.5">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="or" transform="translate(77,27)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_or4_2.v:27$1">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_or4_2.v:27$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_or4_2.v:27$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(142,34.5)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_or4_2.v:27$2">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_or4_2.v:27$2"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_or4_2.v:27$2"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="or" transform="translate(207,42)" s:width="30" s:height="25" id="cell_$or$/app/temp_json/sg13g2_or4_2.v:27$3">
+    <s:alias val="$or"/>
+    <s:alias val="$logic_or"/>
+    <s:alias val="$_OR_"/>
+    <path d="M0,25 L0,25 L15,25 A15 12.5 0 0 0 15,0 L0,0" class="cell_$or$/app/temp_json/sg13g2_or4_2.v:27$3"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$or$/app/temp_json/sg13g2_or4_2.v:27$3"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="30" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(272,44.5)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(77,97)" s:width="30" s:height="20" id="cell_C">
+    <text x="15" y="-4" class="nodelabel cell_C" s:attribute="ref">C</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_C"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(142,104.5)" s:width="30" s:height="20" id="cell_D">
+    <text x="15" y="-4" class="nodelabel cell_D" s:attribute="ref">D</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_D"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="80" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="80" y1="47" y2="47" class="net_4"/>
+  <line x1="107" x2="145" y1="39.5" y2="39.5" class="net_7"/>
+  <line x1="105" x2="117" y1="107" y2="107" class="net_5"/>
+  <line x1="117" x2="117" y1="107" y2="54.5" class="net_5"/>
+  <line x1="117" x2="145" y1="54.5" y2="54.5" class="net_5"/>
+  <line x1="172" x2="210" y1="47" y2="47" class="net_8"/>
+  <line x1="170" x2="182" y1="114.5" y2="114.5" class="net_6"/>
+  <line x1="182" x2="182" y1="114.5" y2="62" class="net_6"/>
+  <line x1="182" x2="210" y1="62" y2="62" class="net_6"/>
+  <line x1="237" x2="272" y1="54.5" y2="54.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_tiehi.svg
+++ b/docs/_static/schematics/sg13g2_tiehi.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="119" height="54">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="outputExt" transform="translate(77,22)" s:width="30" s:height="20" id="cell_L_HI">
+    <text x="15" y="-4" class="nodelabel cell_L_HI" s:attribute="ref">L_HI</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_L_HI"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="constant" transform="translate(12,22)" s:width="30" s:height="20" id="cell_1">
+    <text x="15" y="-4" class="nodelabel cell_1" s:attribute="ref">1</text>
+    <s:alias val="$_constant_"/>
+    <rect width="30" height="20" class="cell_1"/>
+    <g s:x="30" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="42" x2="77" y1="32" y2="32" class="net_0"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_tielo.svg
+++ b/docs/_static/schematics/sg13g2_tielo.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="119" height="54">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="outputExt" transform="translate(77,22)" s:width="30" s:height="20" id="cell_L_LO">
+    <text x="15" y="-4" class="nodelabel cell_L_LO" s:attribute="ref">L_LO</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_L_LO"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="constant" transform="translate(12,22)" s:width="30" s:height="20" id="cell_0">
+    <text x="15" y="-4" class="nodelabel cell_0" s:attribute="ref">0</text>
+    <s:alias val="$_constant_"/>
+    <rect width="30" height="20" class="cell_0"/>
+    <g s:x="30" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="42" x2="77" y1="32" y2="32" class="net_0"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_xnor2_1.svg
+++ b/docs/_static/schematics/sg13g2_xnor2_1.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="252" height="119">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="not" transform="translate(145,29.5)" s:width="30" s:height="20" id="cell_$not$/app/temp_json/sg13g2_xnor2_1.v:0$2">
+    <s:alias val="$_NOT_"/>
+    <s:alias val="$not"/>
+    <s:alias val="$logic_not"/>
+    <path d="M0,0 L0,20 L20,10 Z" class="cell_$not$/app/temp_json/sg13g2_xnor2_1.v:0$2"/>
+    <circle cx="23" cy="10" r="3" class="cell_$not$/app/temp_json/sg13g2_xnor2_1.v:0$2"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+    <g s:x="25" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="reduce_xor" transform="translate(77,27)" s:width="33" s:height="25" id="cell_$xor$/app/temp_json/sg13g2_xnor2_1.v:29$1">
+    <s:alias val="$xor"/>
+    <s:alias val="$reduce_xor"/>
+    <s:alias val="$_XOR_"/>
+    <path d="M3,0 A30 25 0 0 1 3,25 A30 25 0 0 0 33,12.5 A30 25 0 0 0 3,0" class="cell_$xor$/app/temp_json/sg13g2_xnor2_1.v:29$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$xor$/app/temp_json/sg13g2_xnor2_1.v:29$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="33" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(210,29.5)" s:width="30" s:height="20" id="cell_Y">
+    <text x="15" y="-4" class="nodelabel cell_Y" s:attribute="ref">Y</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_Y"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="110" x2="145" y1="39.5" y2="39.5" class="net_5"/>
+  <line x1="40" x2="80" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="80" y1="47" y2="47" class="net_4"/>
+  <line x1="170" x2="210" y1="39.5" y2="39.5" class="net_2"/>
+</svg>

--- a/docs/_static/schematics/sg13g2_xor2_1.svg
+++ b/docs/_static/schematics/sg13g2_xor2_1.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:s="https://github.com/nturley/netlistsvg" width="187" height="119">
+  <style>svg {
+    stroke:#000;
+    fill:none;
+  }
+  text {
+    fill:#000;
+    stroke:none;
+    font-size:10px;
+    font-weight: bold;
+    font-family: "Courier New", monospace;
+  }
+  .nodelabel {
+    text-anchor: middle;
+  }
+  .inputPortLabel {
+    text-anchor: end;
+  }
+  .splitjoinBody {
+    fill:#000;
+  }</style>
+  <g s:type="reduce_xor" transform="translate(77,27)" s:width="33" s:height="25" id="cell_$xor$/app/temp_json/sg13g2_xor2_1.v:27$1">
+    <s:alias val="$xor"/>
+    <s:alias val="$reduce_xor"/>
+    <s:alias val="$_XOR_"/>
+    <path d="M3,0 A30 25 0 0 1 3,25 A30 25 0 0 0 33,12.5 A30 25 0 0 0 3,0" class="cell_$xor$/app/temp_json/sg13g2_xor2_1.v:27$1"/>
+    <path d="M0,0 A30 25 0 0 1 0,25" class="cell_$xor$/app/temp_json/sg13g2_xor2_1.v:27$1"/>
+    <g s:x="3" s:y="5" s:pid="A"/>
+    <g s:x="3" s:y="20" s:pid="B"/>
+    <g s:x="33" s:y="12.5" s:pid="Y"/>
+  </g>
+  <g s:type="outputExt" transform="translate(145,29.5)" s:width="30" s:height="20" id="cell_X">
+    <text x="15" y="-4" class="nodelabel cell_X" s:attribute="ref">X</text>
+    <s:alias val="$_outputExt_"/>
+    <path d="M30,0 L30,20 L15,20 L0,10 L15,0 Z" class="cell_X"/>
+    <g s:x="0" s:y="10" s:pid="A"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,22)" s:width="30" s:height="20" id="cell_A">
+    <text x="15" y="-4" class="nodelabel cell_A" s:attribute="ref">A</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_A"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <g s:type="inputExt" transform="translate(12,87)" s:width="30" s:height="20" id="cell_B">
+    <text x="15" y="-4" class="nodelabel cell_B" s:attribute="ref">B</text>
+    <s:alias val="$_inputExt_"/>
+    <path d="M0,0 L0,20 L15,20 L30,10 L15,0 Z" class="cell_B"/>
+    <g s:x="28" s:y="10" s:pid="Y"/>
+  </g>
+  <line x1="40" x2="80" y1="32" y2="32" class="net_3"/>
+  <line x1="40" x2="52" y1="97" y2="97" class="net_4"/>
+  <line x1="52" x2="52" y1="97" y2="47" class="net_4"/>
+  <line x1="52" x2="80" y1="47" y2="47" class="net_4"/>
+  <line x1="110" x2="145" y1="39.5" y2="39.5" class="net_2"/>
+</svg>

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21o_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21o_1.rst
@@ -10,6 +10,15 @@ sg13g2_a21o_1
 -  **Inputs**:  3 (A1, A2, B1)
 -  **Outputs**: 1 (X)
 
+sg13g2_a21o_1 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_a21o_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_a21o_1 schematic
+
 sg13g2_a21o_1 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_a21o_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_a21o_1
+    sg13g2_a21o_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21o_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21o_2.rst
@@ -10,6 +10,15 @@ sg13g2_a21o_2
 -  **Inputs**:  3 (A1, A2, B1)
 -  **Outputs**: 1 (X)
 
+sg13g2_a21o_2 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_a21o_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_a21o_2 schematic
+
 sg13g2_a21o_2 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_a21o_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_a21o_2
+    sg13g2_a21o_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21oi_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21oi_1.rst
@@ -10,6 +10,15 @@ sg13g2_a21oi_1
 -  **Inputs**:  3 (A1, A2, B1)
 -  **Outputs**: 1 (Y)
 
+sg13g2_a21oi_1 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_a21oi_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_a21oi_1 schematic
+
 sg13g2_a21oi_1 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_a21oi_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_a21oi_1
+    sg13g2_a21oi_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21oi_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21oi_2.rst
@@ -10,6 +10,15 @@ sg13g2_a21oi_2
 -  **Inputs**:  3 (A1, A2, B1)
 -  **Outputs**: 1 (Y)
 
+sg13g2_a21oi_2 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_a21oi_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_a21oi_2 schematic
+
 sg13g2_a21oi_2 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_a21oi_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_a21oi_2
+    sg13g2_a21oi_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a221oi_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a221oi_1.rst
@@ -10,6 +10,15 @@ sg13g2_a221oi_1
 -  **Inputs**:  5 (A1, A2, B1, B2, C1)
 -  **Outputs**: 1 (Y)
 
+sg13g2_a221oi_1 schematic
+-------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_a221oi_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_a221oi_1 schematic
+
 sg13g2_a221oi_1 GDSII layouts
 ------------------------------
 
@@ -17,4 +26,4 @@ sg13g2_a221oi_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_a221oi_1
+    sg13g2_a221oi_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a22oi_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a22oi_1.rst
@@ -10,6 +10,15 @@ sg13g2_a22oi_1
 -  **Inputs**:  4 (A1, A2, B1, B2)
 -  **Outputs**: 1 (Y)
 
+sg13g2_a22oi_1 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_a22oi_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_a22oi_1 schematic
+
 sg13g2_a22oi_1 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_a22oi_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_a22oi_1
+    sg13g2_a22oi_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and2_1.rst
@@ -10,6 +10,15 @@ sg13g2_and2_1
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (X)
 
+sg13g2_and2_1 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_and2_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_and2_1 schematic
+
 sg13g2_and2_1 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_and2_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_and2_1
+    sg13g2_and2_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and2_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and2_2.rst
@@ -10,6 +10,15 @@ sg13g2_and2_2
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (X)
 
+sg13g2_and2_2 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_and2_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_and2_2 schematic
+
 sg13g2_and2_2 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_and2_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_and2_2
+    sg13g2_and2_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and3_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and3_1.rst
@@ -10,6 +10,15 @@ sg13g2_and3_1
 -  **Inputs**:  3 (A, B, C)
 -  **Outputs**: 1 (X)
 
+sg13g2_and3_1 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_and3_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_and3_1 schematic
+
 sg13g2_and3_1 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_and3_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_and3_1
+    sg13g2_and3_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and3_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and3_2.rst
@@ -10,6 +10,15 @@ sg13g2_and3_2
 -  **Inputs**:  3 (A, B, C)
 -  **Outputs**: 1 (X)
 
+sg13g2_and3_2 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_and3_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_and3_2 schematic
+
 sg13g2_and3_2 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_and3_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_and3_2
+    sg13g2_and3_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and4_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and4_1.rst
@@ -10,6 +10,15 @@ sg13g2_and4_1
 -  **Inputs**:  4 (A, B, C, D)
 -  **Outputs**: 1 (X)
 
+sg13g2_and4_1 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_and4_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_and4_1 schematic
+
 sg13g2_and4_1 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_and4_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_and4_1
+    sg13g2_and4_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and4_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and4_2.rst
@@ -10,6 +10,15 @@ sg13g2_and4_2
 -  **Inputs**:  4 (A, B, C, D)
 -  **Outputs**: 1 (X)
 
+sg13g2_and4_2 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_and4_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_and4_2 schematic
+
 sg13g2_and4_2 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_and4_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_and4_2
+    sg13g2_and4_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_antennanp.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_antennanp.rst
@@ -10,6 +10,15 @@ Antenna effect protection cell (gate charge) at manufacture, P-diode in N-Well, 
 -  **Inputs**:  1 (A)
 -  **Outputs**: 0 ()
 
+sg13g2_antennanp schematic
+--------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_antennanp.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_antennanp schematic
+
 sg13g2_antennanp GDSII layouts
 -------------------------------
 
@@ -17,4 +26,4 @@ sg13g2_antennanp GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_antennanp
+    sg13g2_antennanp layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_1.rst
@@ -10,6 +10,15 @@ Buffer drive strength 1
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (X)
 
+sg13g2_buf_1 schematic
+----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_buf_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_buf_1 schematic
+
 sg13g2_buf_1 GDSII layouts
 ---------------------------
 
@@ -17,4 +26,4 @@ sg13g2_buf_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_buf_1
+    sg13g2_buf_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_16.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_16.rst
@@ -10,6 +10,15 @@ Buffer drive strength 16
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (X)
 
+sg13g2_buf_16 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_buf_16.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_buf_16 schematic
+
 sg13g2_buf_16 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_buf_16 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_buf_16
+    sg13g2_buf_16 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_2.rst
@@ -10,6 +10,15 @@ Buffer drive strength 2
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (X)
 
+sg13g2_buf_2 schematic
+----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_buf_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_buf_2 schematic
+
 sg13g2_buf_2 GDSII layouts
 ---------------------------
 
@@ -17,4 +26,4 @@ sg13g2_buf_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_buf_2
+    sg13g2_buf_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_4.rst
@@ -10,6 +10,15 @@ Buffer drive strength 4
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (X)
 
+sg13g2_buf_4 schematic
+----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_buf_4.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_buf_4 schematic
+
 sg13g2_buf_4 GDSII layouts
 ---------------------------
 
@@ -17,4 +26,4 @@ sg13g2_buf_4 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_buf_4
+    sg13g2_buf_4 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_8.rst
@@ -10,6 +10,15 @@ Buffer drive strength 8
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (X)
 
+sg13g2_buf_8 schematic
+----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_buf_8.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_buf_8 schematic
+
 sg13g2_buf_8 GDSII layouts
 ---------------------------
 
@@ -17,4 +26,4 @@ sg13g2_buf_8 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_buf_8
+    sg13g2_buf_8 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_decap_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_decap_4.rst
@@ -10,6 +10,15 @@ Decoupling capasitance filler cell
 -  **Inputs**:  0 ()
 -  **Outputs**: 0 ()
 
+sg13g2_decap_4 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_decap_4.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_decap_4 schematic
+
 sg13g2_decap_4 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_decap_4 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_decap_4
+    sg13g2_decap_4 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_decap_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_decap_8.rst
@@ -10,6 +10,15 @@ Decoupling capasitance filler cell
 -  **Inputs**:  0 ()
 -  **Outputs**: 0 ()
 
+sg13g2_decap_8 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_decap_8.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_decap_8 schematic
+
 sg13g2_decap_8 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_decap_8 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_decap_8
+    sg13g2_decap_8 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbp_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbp_1.rst
@@ -10,6 +10,15 @@ Posedge Two-Outputs Q and Q_N D-Flip-Flop with Low-Active Reset
 -  **Inputs**:  3 (CLK, D, RESET_B)
 -  **Outputs**: 2 (Q, Q_N)
 
+sg13g2_dfrbp_1 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_dfrbp_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_dfrbp_1 schematic
+
 sg13g2_dfrbp_1 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_dfrbp_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_dfrbp_1
+    sg13g2_dfrbp_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbp_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbp_2.rst
@@ -10,6 +10,15 @@ Posedge Two-Outputs Q and Q_N D-Flip-Flop with Low-Active Reset
 -  **Inputs**:  3 (CLK, D, RESET_B)
 -  **Outputs**: 2 (Q, Q_N)
 
+sg13g2_dfrbp_2 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_dfrbp_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_dfrbp_2 schematic
+
 sg13g2_dfrbp_2 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_dfrbp_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_dfrbp_2
+    sg13g2_dfrbp_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbpq_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbpq_1.rst
@@ -10,6 +10,15 @@ Posedge Single-Output Q D-Flip-Flop with Low-Active Reset
 -  **Inputs**:  3 (CLK, D, RESET_B)
 -  **Outputs**: 1 (Q)
 
+sg13g2_dfrbpq_1 schematic
+-------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_dfrbpq_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_dfrbpq_1 schematic
+
 sg13g2_dfrbpq_1 GDSII layouts
 ------------------------------
 
@@ -17,4 +26,4 @@ sg13g2_dfrbpq_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_dfrbpq_1
+    sg13g2_dfrbpq_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbpq_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbpq_2.rst
@@ -10,6 +10,15 @@ Posedge Single-Output Q D-Flip-Flop with Low-Active Reset
 -  **Inputs**:  3 (CLK, D, RESET_B)
 -  **Outputs**: 1 (Q)
 
+sg13g2_dfrbpq_2 schematic
+-------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_dfrbpq_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_dfrbpq_2 schematic
+
 sg13g2_dfrbpq_2 GDSII layouts
 ------------------------------
 
@@ -17,4 +26,4 @@ sg13g2_dfrbpq_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_dfrbpq_2
+    sg13g2_dfrbpq_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhq_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhq_1.rst
@@ -10,6 +10,15 @@ High-Active GATE Single-Output Q D-latch
 -  **Inputs**:  2 (D, GATE)
 -  **Outputs**: 1 (Q)
 
+sg13g2_dlhq_1 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_dlhq_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_dlhq_1 schematic
+
 sg13g2_dlhq_1 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_dlhq_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_dlhq_1
+    sg13g2_dlhq_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhr_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhr_1.rst
@@ -10,6 +10,15 @@ High-Active GATE Two-Outputs Q Q_N D-latch with Low-Active Reset
 -  **Inputs**:  3 (D, GATE, RESET_B)
 -  **Outputs**: 2 (Q, Q_N)
 
+sg13g2_dlhr_1 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_dlhr_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_dlhr_1 schematic
+
 sg13g2_dlhr_1 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_dlhr_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_dlhr_1
+    sg13g2_dlhr_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhrq_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhrq_1.rst
@@ -10,6 +10,15 @@ High-Active Gate Single-Output Q D-latch with Low-Active Reset
 -  **Inputs**:  3 (D, GATE, RESET_B)
 -  **Outputs**: 1 (Q)
 
+sg13g2_dlhrq_1 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_dlhrq_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_dlhrq_1 schematic
+
 sg13g2_dlhrq_1 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_dlhrq_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_dlhrq_1
+    sg13g2_dlhrq_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dllr_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dllr_1.rst
@@ -10,6 +10,15 @@ Low-Active GATE_N Two-Outputs Q Q_N D-latch with Low-Active Reset
 -  **Inputs**:  3 (D, GATE_N, RESET_B)
 -  **Outputs**: 2 (Q, Q_N)
 
+sg13g2_dllr_1 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_dllr_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_dllr_1 schematic
+
 sg13g2_dllr_1 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_dllr_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_dllr_1
+    sg13g2_dllr_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dllrq_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dllrq_1.rst
@@ -10,6 +10,15 @@ Low-Active GATE_N Single-Output Q D-latch with Low-Active Reset
 -  **Inputs**:  3 (D, GATE_N, RESET_B)
 -  **Outputs**: 1 (Q)
 
+sg13g2_dllrq_1 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_dllrq_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_dllrq_1 schematic
+
 sg13g2_dllrq_1 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_dllrq_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_dllrq_1
+    sg13g2_dllrq_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd1_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd1_1.rst
@@ -10,6 +10,15 @@ Delay Cell, typical 0.4 ns
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (X)
 
+sg13g2_dlygate4sd1_1 schematic
+------------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_dlygate4sd1_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_dlygate4sd1_1 schematic
+
 sg13g2_dlygate4sd1_1 GDSII layouts
 -----------------------------------
 
@@ -17,4 +26,4 @@ sg13g2_dlygate4sd1_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_dlygate4sd1_1
+    sg13g2_dlygate4sd1_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd2_1.rst
@@ -10,6 +10,15 @@ Delay Cell, typical 0.45 ns
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (X)
 
+sg13g2_dlygate4sd2_1 schematic
+------------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_dlygate4sd2_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_dlygate4sd2_1 schematic
+
 sg13g2_dlygate4sd2_1 GDSII layouts
 -----------------------------------
 
@@ -17,4 +26,4 @@ sg13g2_dlygate4sd2_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_dlygate4sd2_1
+    sg13g2_dlygate4sd2_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd3_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd3_1.rst
@@ -10,6 +10,15 @@ Delay Cell, typical 0.7 ns
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (X)
 
+sg13g2_dlygate4sd3_1 schematic
+------------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_dlygate4sd3_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_dlygate4sd3_1 schematic
+
 sg13g2_dlygate4sd3_1 GDSII layouts
 -----------------------------------
 
@@ -17,4 +26,4 @@ sg13g2_dlygate4sd3_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_dlygate4sd3_1
+    sg13g2_dlygate4sd3_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_2.rst
@@ -10,6 +10,15 @@ Tristate Buffer with Low-Active Enable TE_B
 -  **Inputs**:  2 (A, TE_B)
 -  **Outputs**: 1 (Z)
 
+sg13g2_ebufn_2 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_ebufn_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_ebufn_2 schematic
+
 sg13g2_ebufn_2 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_ebufn_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_ebufn_2
+    sg13g2_ebufn_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_4.rst
@@ -10,6 +10,15 @@ Tristate Buffer with Low-Active Enable TE_B
 -  **Inputs**:  2 (A, TE_B)
 -  **Outputs**: 1 (Z)
 
+sg13g2_ebufn_4 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_ebufn_4.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_ebufn_4 schematic
+
 sg13g2_ebufn_4 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_ebufn_4 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_ebufn_4
+    sg13g2_ebufn_4 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_8.rst
@@ -10,6 +10,15 @@ Tristate Buffer with Low-Active Enable TE_B
 -  **Inputs**:  2 (A, TE_B)
 -  **Outputs**: 1 (Z)
 
+sg13g2_ebufn_8 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_ebufn_8.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_ebufn_8 schematic
+
 sg13g2_ebufn_8 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_ebufn_8 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_ebufn_8
+    sg13g2_ebufn_8 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_2.rst
@@ -10,6 +10,15 @@ Tristate Inverter with Low-Active Enable TE_B
 -  **Inputs**:  2 (A, TE_B)
 -  **Outputs**: 1 (Z)
 
+sg13g2_einvn_2 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_einvn_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_einvn_2 schematic
+
 sg13g2_einvn_2 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_einvn_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_einvn_2
+    sg13g2_einvn_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_4.rst
@@ -10,6 +10,15 @@ Tristate Inverter with Low-Active Enable TE_B
 -  **Inputs**:  2 (A, TE_B)
 -  **Outputs**: 1 (Z)
 
+sg13g2_einvn_4 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_einvn_4.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_einvn_4 schematic
+
 sg13g2_einvn_4 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_einvn_4 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_einvn_4
+    sg13g2_einvn_4 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_8.rst
@@ -10,6 +10,15 @@ Tristate Inverter with Low-Active Enable TE_B
 -  **Inputs**:  2 (A, TE_B)
 -  **Outputs**: 1 (Z)
 
+sg13g2_einvn_8 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_einvn_8.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_einvn_8 schematic
+
 sg13g2_einvn_8 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_einvn_8 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_einvn_8
+    sg13g2_einvn_8 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_1.rst
@@ -10,6 +10,15 @@ Filler 1 Track Width
 -  **Inputs**:  0 ()
 -  **Outputs**: 0 ()
 
+sg13g2_fill_1 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_fill_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_fill_1 schematic
+
 sg13g2_fill_1 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_fill_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_fill_1
+    sg13g2_fill_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_2.rst
@@ -10,6 +10,15 @@ Filler 2 Tracks Width
 -  **Inputs**:  0 ()
 -  **Outputs**: 0 ()
 
+sg13g2_fill_2 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_fill_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_fill_2 schematic
+
 sg13g2_fill_2 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_fill_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_fill_2
+    sg13g2_fill_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_4.rst
@@ -10,6 +10,15 @@ Filler 4 Tracks Width
 -  **Inputs**:  0 ()
 -  **Outputs**: 0 ()
 
+sg13g2_fill_4 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_fill_4.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_fill_4 schematic
+
 sg13g2_fill_4 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_fill_4 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_fill_4
+    sg13g2_fill_4 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_8.rst
@@ -10,6 +10,15 @@ Filler 8 Tracks Width
 -  **Inputs**:  0 ()
 -  **Outputs**: 0 ()
 
+sg13g2_fill_8 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_fill_8.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_fill_8 schematic
+
 sg13g2_fill_8 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_fill_8 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_fill_8
+    sg13g2_fill_8 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_1.rst
@@ -10,6 +10,15 @@ Inverter
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (Y)
 
+sg13g2_inv_1 schematic
+----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_inv_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_inv_1 schematic
+
 sg13g2_inv_1 GDSII layouts
 ---------------------------
 
@@ -17,4 +26,4 @@ sg13g2_inv_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_inv_1
+    sg13g2_inv_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_16.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_16.rst
@@ -10,6 +10,15 @@ Inverter
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (Y)
 
+sg13g2_inv_16 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_inv_16.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_inv_16 schematic
+
 sg13g2_inv_16 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_inv_16 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_inv_16
+    sg13g2_inv_16 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_2.rst
@@ -10,6 +10,15 @@ Inverter
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (Y)
 
+sg13g2_inv_2 schematic
+----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_inv_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_inv_2 schematic
+
 sg13g2_inv_2 GDSII layouts
 ---------------------------
 
@@ -17,4 +26,4 @@ sg13g2_inv_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_inv_2
+    sg13g2_inv_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_4.rst
@@ -10,6 +10,15 @@ Inverter
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (Y)
 
+sg13g2_inv_4 schematic
+----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_inv_4.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_inv_4 schematic
+
 sg13g2_inv_4 GDSII layouts
 ---------------------------
 
@@ -17,4 +26,4 @@ sg13g2_inv_4 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_inv_4
+    sg13g2_inv_4 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_8.rst
@@ -10,6 +10,15 @@ Inverter
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (Y)
 
+sg13g2_inv_8 schematic
+----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_inv_8.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_inv_8 schematic
+
 sg13g2_inv_8 GDSII layouts
 ---------------------------
 
@@ -17,4 +26,4 @@ sg13g2_inv_8 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_inv_8
+    sg13g2_inv_8 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_lgcp_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_lgcp_1.rst
@@ -10,6 +10,15 @@ Posedge Clock Gating cell, Low Latch Enable
 -  **Inputs**:  2 (CLK, GATE)
 -  **Outputs**: 1 (GCLK)
 
+sg13g2_lgcp_1 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_lgcp_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_lgcp_1 schematic
+
 sg13g2_lgcp_1 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_lgcp_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_lgcp_1
+    sg13g2_lgcp_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux2_1.rst
@@ -10,6 +10,15 @@ Multiplexer from 2 to 1
 -  **Inputs**:  3 (A0, A1, S)
 -  **Outputs**: 1 (X)
 
+sg13g2_mux2_1 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_mux2_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_mux2_1 schematic
+
 sg13g2_mux2_1 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_mux2_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_mux2_1
+    sg13g2_mux2_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux2_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux2_2.rst
@@ -10,6 +10,15 @@ Multiplexer from 2 to 1
 -  **Inputs**:  3 (A0, A1, S)
 -  **Outputs**: 1 (X)
 
+sg13g2_mux2_2 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_mux2_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_mux2_2 schematic
+
 sg13g2_mux2_2 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_mux2_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_mux2_2
+    sg13g2_mux2_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux4_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux4_1.rst
@@ -10,6 +10,15 @@ Multiplexer from 4 to 1
 -  **Inputs**:  6 (A0, A1, A2, A3, S0, S1)
 -  **Outputs**: 1 (X)
 
+sg13g2_mux4_1 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_mux4_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_mux4_1 schematic
+
 sg13g2_mux4_1 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_mux4_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_mux4_1
+    sg13g2_mux4_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2_1.rst
@@ -10,6 +10,15 @@ sg13g2_nand2_1
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nand2_1 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_nand2_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_nand2_1 schematic
+
 sg13g2_nand2_1 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_nand2_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_nand2_1
+    sg13g2_nand2_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2_2.rst
@@ -10,6 +10,15 @@ sg13g2_nand2_2
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nand2_2 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_nand2_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_nand2_2 schematic
+
 sg13g2_nand2_2 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_nand2_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_nand2_2
+    sg13g2_nand2_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2b_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2b_1.rst
@@ -10,6 +10,15 @@ sg13g2_nand2b_1
 -  **Inputs**:  2 (A_N, B)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nand2b_1 schematic
+-------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_nand2b_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_nand2b_1 schematic
+
 sg13g2_nand2b_1 GDSII layouts
 ------------------------------
 
@@ -17,4 +26,4 @@ sg13g2_nand2b_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_nand2b_1
+    sg13g2_nand2b_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2b_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2b_2.rst
@@ -10,6 +10,15 @@ sg13g2_nand2b_2
 -  **Inputs**:  2 (A_N, B)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nand2b_2 schematic
+-------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_nand2b_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_nand2b_2 schematic
+
 sg13g2_nand2b_2 GDSII layouts
 ------------------------------
 
@@ -17,4 +26,4 @@ sg13g2_nand2b_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_nand2b_2
+    sg13g2_nand2b_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand3_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand3_1.rst
@@ -10,6 +10,15 @@ sg13g2_nand3_1
 -  **Inputs**:  3 (A, B, C)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nand3_1 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_nand3_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_nand3_1 schematic
+
 sg13g2_nand3_1 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_nand3_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_nand3_1
+    sg13g2_nand3_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand3b_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand3b_1.rst
@@ -10,6 +10,15 @@ sg13g2_nand3b_1
 -  **Inputs**:  3 (A_N, B, C)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nand3b_1 schematic
+-------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_nand3b_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_nand3b_1 schematic
+
 sg13g2_nand3b_1 GDSII layouts
 ------------------------------
 
@@ -17,4 +26,4 @@ sg13g2_nand3b_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_nand3b_1
+    sg13g2_nand3b_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand4_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand4_1.rst
@@ -10,6 +10,15 @@ sg13g2_nand4_1
 -  **Inputs**:  4 (A, B, C, D)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nand4_1 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_nand4_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_nand4_1 schematic
+
 sg13g2_nand4_1 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_nand4_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_nand4_1
+    sg13g2_nand4_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2_1.rst
@@ -10,6 +10,15 @@ sg13g2_nor2_1
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nor2_1 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_nor2_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_nor2_1 schematic
+
 sg13g2_nor2_1 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_nor2_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_nor2_1
+    sg13g2_nor2_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2_2.rst
@@ -10,6 +10,15 @@ sg13g2_nor2_2
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nor2_2 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_nor2_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_nor2_2 schematic
+
 sg13g2_nor2_2 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_nor2_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_nor2_2
+    sg13g2_nor2_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2b_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2b_1.rst
@@ -10,6 +10,15 @@ sg13g2_nor2b_1
 -  **Inputs**:  2 (A, B_N)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nor2b_1 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_nor2b_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_nor2b_1 schematic
+
 sg13g2_nor2b_1 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_nor2b_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_nor2b_1
+    sg13g2_nor2b_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2b_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2b_2.rst
@@ -10,6 +10,15 @@ sg13g2_nor2b_2
 -  **Inputs**:  2 (A, B_N)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nor2b_2 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_nor2b_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_nor2b_2 schematic
+
 sg13g2_nor2b_2 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_nor2b_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_nor2b_2
+    sg13g2_nor2b_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor3_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor3_1.rst
@@ -10,6 +10,15 @@ sg13g2_nor3_1
 -  **Inputs**:  3 (A, B, C)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nor3_1 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_nor3_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_nor3_1 schematic
+
 sg13g2_nor3_1 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_nor3_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_nor3_1
+    sg13g2_nor3_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor3_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor3_2.rst
@@ -10,6 +10,15 @@ sg13g2_nor3_2
 -  **Inputs**:  3 (A, B, C)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nor3_2 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_nor3_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_nor3_2 schematic
+
 sg13g2_nor3_2 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_nor3_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_nor3_2
+    sg13g2_nor3_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor4_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor4_1.rst
@@ -10,6 +10,15 @@ sg13g2_nor4_1
 -  **Inputs**:  4 (A, B, C, D)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nor4_1 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_nor4_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_nor4_1 schematic
+
 sg13g2_nor4_1 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_nor4_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_nor4_1
+    sg13g2_nor4_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor4_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor4_2.rst
@@ -10,6 +10,15 @@ sg13g2_nor4_2
 -  **Inputs**:  4 (A, B, C, D)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nor4_2 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_nor4_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_nor4_2 schematic
+
 sg13g2_nor4_2 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_nor4_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_nor4_2
+    sg13g2_nor4_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_o21ai_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_o21ai_1.rst
@@ -10,6 +10,15 @@ sg13g2_o21ai_1
 -  **Inputs**:  3 (A1, A2, B1)
 -  **Outputs**: 1 (Y)
 
+sg13g2_o21ai_1 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_o21ai_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_o21ai_1 schematic
+
 sg13g2_o21ai_1 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_o21ai_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_o21ai_1
+    sg13g2_o21ai_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or2_1.rst
@@ -10,6 +10,15 @@ sg13g2_or2_1
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (X)
 
+sg13g2_or2_1 schematic
+----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_or2_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_or2_1 schematic
+
 sg13g2_or2_1 GDSII layouts
 ---------------------------
 
@@ -17,4 +26,4 @@ sg13g2_or2_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_or2_1
+    sg13g2_or2_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or2_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or2_2.rst
@@ -10,6 +10,15 @@ sg13g2_or2_2
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (X)
 
+sg13g2_or2_2 schematic
+----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_or2_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_or2_2 schematic
+
 sg13g2_or2_2 GDSII layouts
 ---------------------------
 
@@ -17,4 +26,4 @@ sg13g2_or2_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_or2_2
+    sg13g2_or2_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or3_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or3_1.rst
@@ -10,6 +10,15 @@ sg13g2_or3_1
 -  **Inputs**:  3 (A, B, C)
 -  **Outputs**: 1 (X)
 
+sg13g2_or3_1 schematic
+----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_or3_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_or3_1 schematic
+
 sg13g2_or3_1 GDSII layouts
 ---------------------------
 
@@ -17,4 +26,4 @@ sg13g2_or3_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_or3_1
+    sg13g2_or3_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or3_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or3_2.rst
@@ -10,6 +10,15 @@ sg13g2_or3_2
 -  **Inputs**:  3 (A, B, C)
 -  **Outputs**: 1 (X)
 
+sg13g2_or3_2 schematic
+----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_or3_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_or3_2 schematic
+
 sg13g2_or3_2 GDSII layouts
 ---------------------------
 
@@ -17,4 +26,4 @@ sg13g2_or3_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_or3_2
+    sg13g2_or3_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or4_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or4_1.rst
@@ -10,6 +10,15 @@ sg13g2_or4_1
 -  **Inputs**:  4 (A, B, C, D)
 -  **Outputs**: 1 (X)
 
+sg13g2_or4_1 schematic
+----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_or4_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_or4_1 schematic
+
 sg13g2_or4_1 GDSII layouts
 ---------------------------
 
@@ -17,4 +26,4 @@ sg13g2_or4_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_or4_1
+    sg13g2_or4_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or4_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or4_2.rst
@@ -10,6 +10,15 @@ sg13g2_or4_2
 -  **Inputs**:  4 (A, B, C, D)
 -  **Outputs**: 1 (X)
 
+sg13g2_or4_2 schematic
+----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_or4_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_or4_2 schematic
+
 sg13g2_or4_2 GDSII layouts
 ---------------------------
 
@@ -17,4 +26,4 @@ sg13g2_or4_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_or4_2
+    sg13g2_or4_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfbbp_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfbbp_1.rst
@@ -10,6 +10,15 @@ Posedge Two-Outputs D-Flip-Flop with Reset, Set and Scan
 -  **Inputs**:  6 (CLK, D, RESET_B, SCD, SCE, SET_B)
 -  **Outputs**: 2 (Q, Q_N)
 
+sg13g2_sdfbbp_1 schematic
+-------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_sdfbbp_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_sdfbbp_1 schematic
+
 sg13g2_sdfbbp_1 GDSII layouts
 ------------------------------
 
@@ -17,4 +26,4 @@ sg13g2_sdfbbp_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_sdfbbp_1
+    sg13g2_sdfbbp_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbp_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbp_1.rst
@@ -10,6 +10,15 @@ Posedge Two-Outputs Q and Q_N D-Flip-Flop with Reset and Scan
 -  **Inputs**:  5 (CLK, D, RESET_B, SCD, SCE)
 -  **Outputs**: 2 (Q, Q_N)
 
+sg13g2_sdfrbp_1 schematic
+-------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_sdfrbp_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_sdfrbp_1 schematic
+
 sg13g2_sdfrbp_1 GDSII layouts
 ------------------------------
 
@@ -17,4 +26,4 @@ sg13g2_sdfrbp_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_sdfrbp_1
+    sg13g2_sdfrbp_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbp_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbp_2.rst
@@ -10,6 +10,15 @@ Posedge Two-Outputs Q and Q_N D-Flip-Flop with Reset and Scan
 -  **Inputs**:  5 (CLK, D, RESET_B, SCD, SCE)
 -  **Outputs**: 2 (Q, Q_N)
 
+sg13g2_sdfrbp_2 schematic
+-------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_sdfrbp_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_sdfrbp_2 schematic
+
 sg13g2_sdfrbp_2 GDSII layouts
 ------------------------------
 
@@ -17,4 +26,4 @@ sg13g2_sdfrbp_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_sdfrbp_2
+    sg13g2_sdfrbp_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbpq_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbpq_1.rst
@@ -10,6 +10,15 @@ Posedge Single-Output Q D-Flip-Flop with Reset and Scan
 -  **Inputs**:  5 (CLK, D, RESET_B, SCD, SCE)
 -  **Outputs**: 1 (Q)
 
+sg13g2_sdfrbpq_1 schematic
+--------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_sdfrbpq_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_sdfrbpq_1 schematic
+
 sg13g2_sdfrbpq_1 GDSII layouts
 -------------------------------
 
@@ -17,4 +26,4 @@ sg13g2_sdfrbpq_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_sdfrbpq_1
+    sg13g2_sdfrbpq_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbpq_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbpq_2.rst
@@ -10,6 +10,15 @@ Posedge Single-Output Q D-Flip-Flop with Reset and Scan
 -  **Inputs**:  5 (CLK, D, RESET_B, SCD, SCE)
 -  **Outputs**: 1 (Q)
 
+sg13g2_sdfrbpq_2 schematic
+--------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_sdfrbpq_2.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_sdfrbpq_2 schematic
+
 sg13g2_sdfrbpq_2 GDSII layouts
 -------------------------------
 
@@ -17,4 +26,4 @@ sg13g2_sdfrbpq_2 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_sdfrbpq_2
+    sg13g2_sdfrbpq_2 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sighold.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sighold.rst
@@ -10,6 +10,15 @@ Leakage current compensator (bus holder)
 -  **Inputs**:  0 ()
 -  **Outputs**: 0 ()
 
+sg13g2_sighold schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_sighold.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_sighold schematic
+
 sg13g2_sighold GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_sighold GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_sighold
+    sg13g2_sighold layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_slgcp_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_slgcp_1.rst
@@ -10,6 +10,15 @@ Scan gated clock
 -  **Inputs**:  3 (GATE, CLK, SCE)
 -  **Outputs**: 1 (GCLK)
 
+sg13g2_slgcp_1 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_slgcp_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_slgcp_1 schematic
+
 sg13g2_slgcp_1 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_slgcp_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_slgcp_1
+    sg13g2_slgcp_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_tiehi.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_tiehi.rst
@@ -10,6 +10,15 @@ Constant logic 0
 -  **Inputs**:  0 ()
 -  **Outputs**: 1 (L_HI)
 
+sg13g2_tiehi schematic
+----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_tiehi.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_tiehi schematic
+
 sg13g2_tiehi GDSII layouts
 ---------------------------
 
@@ -17,4 +26,4 @@ sg13g2_tiehi GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_tiehi
+    sg13g2_tiehi layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_tielo.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_tielo.rst
@@ -10,6 +10,15 @@ Constant logic 1
 -  **Inputs**:  0 ()
 -  **Outputs**: 1 (L_LO)
 
+sg13g2_tielo schematic
+----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_tielo.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_tielo schematic
+
 sg13g2_tielo GDSII layouts
 ---------------------------
 
@@ -17,4 +26,4 @@ sg13g2_tielo GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_tielo
+    sg13g2_tielo layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_xnor2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_xnor2_1.rst
@@ -10,6 +10,15 @@ sg13g2_xnor2_1
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (Y)
 
+sg13g2_xnor2_1 schematic
+------------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_xnor2_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_xnor2_1 schematic
+
 sg13g2_xnor2_1 GDSII layouts
 -----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_xnor2_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_xnor2_1
+    sg13g2_xnor2_1 layout

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_xor2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_xor2_1.rst
@@ -10,6 +10,15 @@ sg13g2_xor2_1
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (X)
 
+sg13g2_xor2_1 schematic
+-----------------------
+
+.. figure:: ../../../_static/schematics/sg13g2_xor2_1.svg
+    :align: center
+    :width: 80%
+
+    sg13g2_xor2_1 schematic
+
 sg13g2_xor2_1 GDSII layouts
 ----------------------------
 
@@ -17,4 +26,4 @@ sg13g2_xor2_1 GDSII layouts
     :align: center
     :width: 80%
 
-    sg13g2_xor2_1
+    sg13g2_xor2_1 layout

--- a/scripts/generate_cell_docs.py
+++ b/scripts/generate_cell_docs.py
@@ -110,6 +110,15 @@ def generate_rst(cell, output_dir, image_relative_path):
         f.write(f"-  **Inputs**:  {len(cell['inputs'])} ({', '.join(cell['inputs'])})\n")
         f.write(f"-  **Outputs**: {len(cell['outputs'])} ({', '.join(cell['outputs'])})\n\n")
 
+        f.write(f"{cell['name']} schematic\n")
+        f.write("-" * (len(cell['name']) + 10) + "\n\n")
+
+        schematic_name = f"{cell['name']}.svg"
+        f.write(f".. figure:: ../../../_static/schematics/{schematic_name}\n")
+        f.write("    :align: center\n")
+        f.write("    :width: 80%\n\n")
+        f.write(f"    {cell['name']} schematic\n\n")
+
         f.write(f"{cell['name']} GDSII layouts\n")
         f.write("-" * (len(cell['name']) + 15) + "\n\n")
 
@@ -117,7 +126,7 @@ def generate_rst(cell, output_dir, image_relative_path):
         f.write(f".. figure:: ../../../_static/images/{image_name}\n")
         f.write("    :align: center\n")
         f.write("    :width: 80%\n\n")
-        f.write(f"    {cell['name']}\n")
+        f.write(f"    {cell['name']} layout\n")
 
 
 def main():
@@ -138,12 +147,14 @@ def main():
     os.makedirs(image_dst_dir, exist_ok=True)
     os.makedirs(output_dir, exist_ok=True)
 
+    image_count = 0
     for cell in cells:
         generate_rst(cell, output_dir, None)
         image_name = f"{cell['name']}.png"
         src_image = os.path.join(image_src_dir, image_name)
         if os.path.exists(src_image):
             shutil.copy(src_image, os.path.join(image_dst_dir, image_name))
+            image_count += 1
 
     print(f"Generated {len(cells)} documentation files.")
     if image_count > 0:

--- a/scripts/generate_schematics.py
+++ b/scripts/generate_schematics.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import re
+import shutil
+
+
+def get_cells(verilog_path):
+    if not os.path.exists(verilog_path):
+        return []
+    with open(verilog_path, 'r') as f:
+        content = f.read()
+
+    # Simple parser to extract modules
+    # Split into blocks, each ending with 'endmodule'
+    blocks = []
+    last_pos = 0
+    for match in re.finditer(r'endmodule', content):
+        blocks.append(content[last_pos:match.end()])
+        last_pos = match.end()
+
+    cells = []
+    for block in blocks:
+        mod_match = re.search(r'module\s+(\w+)\s*\((.*?)\);', block, re.DOTALL)
+        if mod_match:
+            cell_name = mod_match.group(1)
+            # Remove specify blocks from this cell's code
+            clean_block = re.sub(r'specify.*?endspecify', '', block, flags=re.DOTALL)
+            # Remove attributes
+            clean_block = re.sub(r'\(\*.*?\*\)', '', clean_block, flags=re.DOTALL)
+            # Fix gate constants
+            clean_block = re.sub(r'(\b(and|or|nand|nor|xor|xnor|buf|not)\s*\(.*?,)\s*0\s*\)', r"\1 1'b0)", clean_block)
+            clean_block = re.sub(r'(\b(and|or|nand|nor|xor|xnor|buf|not)\s*\(.*?,)\s*1\s*\)', r"\1 1'b1)", clean_block)
+            cells.append({'name': cell_name, 'code': clean_block})
+    return cells
+
+
+def generate_schematics():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    repo_root = os.path.abspath(os.path.join(script_dir, ".."))
+
+    verilog_path = os.path.join(repo_root, "ihp-sg13g2/libs.ref/sg13g2_stdcell/verilog/sg13g2_stdcell.v")
+    output_dir = os.path.join(repo_root, "docs/_static/schematics")
+    temp_dir = os.path.join(repo_root, "temp_json")
+
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    if not os.path.exists(temp_dir):
+        os.makedirs(temp_dir)
+
+    cells = get_cells(verilog_path)
+    print(f"Found {len(cells)} cells. Generating schematics...")
+
+    blackboxes = """
+module ihp_dff_r (q, v, clk, d, r, xcr); output q; input v, clk, d, r, xcr; endmodule
+module ihp_dff_s (q, v, clk, d, s, xcs); output q; input v, clk, d, s, xcs; endmodule
+module ihp_dlatch_r (q, v, g, d, r, xcr); output q; input v, g, d, r, xcr; endmodule
+module ihp_dlatch_s (q, v, g, d, s, xcs); output q; input v, g, d, s, xcs; endmodule
+module ihp_dff_rs (q, v, clk, d, r, s, xcr, xcs); output q; input v, clk, d, r, s, xcr, xcs; endmodule
+"""
+
+    for cell in cells:
+        name = cell['name']
+        if "fill" in name or "decap" in name:
+            continue
+
+        v_path = os.path.join(temp_dir, f"{name}.v")
+        json_path = os.path.join(temp_dir, f"{name}.json")
+        svg_path = os.path.join(output_dir, f"{name}.svg")
+
+        with open(v_path, 'w') as f:
+            f.write(blackboxes)
+            f.write(cell['code'])
+
+        # Run Yosys
+        yosys_cmd = [
+            "yosys", "-p",
+            f"read_verilog {v_path}; prep -top {name}; write_json {json_path}"
+        ]
+
+        try:
+            subprocess.run(yosys_cmd, check=True, capture_output=True, text=True)
+
+            # Run netlistsvg
+            netlistsvg_cmd = ["netlistsvg", json_path, "-o", svg_path]
+            subprocess.run(netlistsvg_cmd, check=True, capture_output=True, text=True)
+            print(f"Generated schematic for {name}")
+        except subprocess.CalledProcessError as e:
+            print(f"Error generating schematic for {name}: {e.stderr}")
+
+    # Cleanup temp dir
+    shutil.rmtree(temp_dir)
+    print("Schematic generation complete.")
+
+
+if __name__ == "__main__":
+    generate_schematics()


### PR DESCRIPTION
This change implements Step 11 of the PDK roadmap: Algorithmic Schematic SVG Generation for Documentation. 

Key changes:
1. **New Script `scripts/generate_schematics.py`**: This script uses Yosys to parse the standard cell Verilog netlist and generate JSON netlists, which are then converted to SVG schematics using `netlistsvg`. It includes a robust pre-processing step to remove `specify` blocks and other Verilog constructs that Yosys might struggle with, and provides blackbox models for internal PDK primitives.
2. **Updated `scripts/generate_cell_docs.py`**: 
    - Fixed a `NameError` where `image_count` was used before being defined.
    - Added logic to include the generated SVG schematics in each cell's ReST documentation file.
3. **Documentation Updates**: All standard cell `.rst` files now include a "schematic" section displaying the algorithmically generated diagram.

Dependencies installed:
- `yosys` (via apt)
- `netlistsvg` (via npm)

Fixes #15

---
*PR created automatically by Jules for task [5741242232196366662](https://jules.google.com/task/5741242232196366662) started by @chatelao*