### PR TITLE
Add GitHub Pages link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # IHP Open Source PDK
 130nm BiCMOS Open Source PDK, dedicated for Analog/Digital, Mixed Signal and RF Design
 
+**GitHub Pages:** [https://gdsfactory.github.io/IHP/](https://gdsfactory.github.io/IHP/)
+
 ---
 > [!WARNING]
 > ### 📘 Installation Notice


### PR DESCRIPTION
This change adds a prominent link to the GitHub Pages documentation (https://gdsfactory.github.io/IHP/) at the top of the README.md file, ensuring users can easily find the web-hosted documentation.

Fixes #23

---
*PR created automatically by Jules for task [13390039775257092627](https://jules.google.com/task/13390039775257092627) started by @chatelao*