### PR TITLE
Adjust color palette and rendering style for layout images

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/sg13g2.lyp
+++ b/ihp-sg13g2/libs.tech/klayout/tech/sg13g2.lyp
@@ -49,10 +49,10 @@
   </properties>
   <properties>
     <frame-color>#00ff00</frame-color>
-    <fill-color>#00ff00</fill-color>
+    <fill-color>#b300ff00</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C2</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C2</line-style>
     <valid>true</valid>
     <visible>true</visible>
@@ -241,10 +241,10 @@
   </properties>
   <properties>
     <frame-color>#bf4026</frame-color>
-    <fill-color>#bf4026</fill-color>
+    <fill-color>#b3bf4026</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C7</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C1</line-style>
     <valid>true</valid>
     <visible>true</visible>
@@ -481,10 +481,10 @@
   </properties>
   <properties>
     <frame-color>#268c6b</frame-color>
-    <fill-color>#268c6b</fill-color>
+    <fill-color>#66268c6b</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C9</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C1</line-style>
     <valid>true</valid>
     <visible>true</visible>
@@ -689,10 +689,10 @@
   </properties>
   <properties>
     <frame-color>#ccb899</frame-color>
-    <fill-color>#ccb899</fill-color>
+    <fill-color>#66ccb899</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C12</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C1</line-style>
     <valid>true</valid>
     <visible>true</visible>
@@ -705,10 +705,10 @@
   </properties>
   <properties>
     <frame-color>#00cc66</frame-color>
-    <fill-color>#00cc66</fill-color>
+    <fill-color>#6600cc66</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C13</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C0</line-style>
     <valid>false</valid>
     <visible>true</visible>
@@ -769,10 +769,10 @@
   </properties>
   <properties>
     <frame-color>#00ffff</frame-color>
-    <fill-color>#00ffff</fill-color>
+    <fill-color>#b300ffff</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C17</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C1</line-style>
     <valid>true</valid>
     <visible>true</visible>
@@ -833,10 +833,10 @@
   </properties>
   <properties>
     <frame-color>#39bfff</frame-color>
-    <fill-color>#39bfff</fill-color>
+    <fill-color>#b339bfff</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C1</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C1</line-style>
     <valid>true</valid>
     <visible>true</visible>
@@ -1073,15 +1073,15 @@
   </properties>
   <properties>
     <frame-color>#ccccff</frame-color>
-    <fill-color>#ccccff</fill-color>
+    <fill-color>#b3ccccff</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C20</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C8</line-style>
     <valid>true</valid>
     <visible>true</visible>
     <transparent>false</transparent>
-    <width>2</width>
+    <width>1</width>
     <marked>false</marked>
     <animation>0</animation>
     <name>Via1.drawing</name>
@@ -1121,10 +1121,10 @@
   </properties>
   <properties>
     <frame-color>#ccccd9</frame-color>
-    <fill-color>#ccccd9</fill-color>
+    <fill-color>#b3ccccd9</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C21</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C0</line-style>
     <valid>true</valid>
     <visible>true</visible>
@@ -1361,15 +1361,15 @@
   </properties>
   <properties>
     <frame-color>#ff3736</frame-color>
-    <fill-color>#ff3736</fill-color>
+    <fill-color>#b3ff3736</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C22</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C8</line-style>
     <valid>true</valid>
     <visible>true</visible>
     <transparent>false</transparent>
-    <width>2</width>
+    <width>1</width>
     <marked>false</marked>
     <animation>0</animation>
     <name>Via2.drawing</name>
@@ -1409,10 +1409,10 @@
   </properties>
   <properties>
     <frame-color>#d80000</frame-color>
-    <fill-color>#d80000</fill-color>
+    <fill-color>#b3d80000</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C23</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C0</line-style>
     <valid>true</valid>
     <visible>true</visible>
@@ -1713,15 +1713,15 @@
   </properties>
   <properties>
     <frame-color>#9ba940</frame-color>
-    <fill-color>#9ba940</fill-color>
+    <fill-color>#b39ba940</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C26</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C8</line-style>
     <valid>true</valid>
     <visible>true</visible>
     <transparent>false</transparent>
-    <width>2</width>
+    <width>1</width>
     <marked>false</marked>
     <animation>0</animation>
     <name>Via3.drawing</name>
@@ -1761,10 +1761,10 @@
   </properties>
   <properties>
     <frame-color>#93e837</frame-color>
-    <fill-color>#93e837</fill-color>
+    <fill-color>#b393e837</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C27</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C1</line-style>
     <valid>true</valid>
     <visible>true</visible>
@@ -2001,15 +2001,15 @@
   </properties>
   <properties>
     <frame-color>#deac5e</frame-color>
-    <fill-color>#deac5e</fill-color>
+    <fill-color>#b3deac5e</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C28</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C8</line-style>
     <valid>true</valid>
     <visible>true</visible>
     <transparent>false</transparent>
-    <width>2</width>
+    <width>1</width>
     <marked>false</marked>
     <animation>0</animation>
     <name>Via4.drawing</name>
@@ -2049,10 +2049,10 @@
   </properties>
   <properties>
     <frame-color>#dcd146</frame-color>
-    <fill-color>#dcd146</fill-color>
+    <fill-color>#b3dcd146</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C29</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C0</line-style>
     <valid>true</valid>
     <visible>true</visible>
@@ -2289,10 +2289,10 @@
   </properties>
   <properties>
     <frame-color>#ffe6bf</frame-color>
-    <fill-color>#ffe6bf</fill-color>
+    <fill-color>#b3ffe6bf</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C25</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C8</line-style>
     <valid>true</valid>
     <visible>true</visible>
@@ -2337,10 +2337,10 @@
   </properties>
   <properties>
     <frame-color>#ffe6bf</frame-color>
-    <fill-color>#ffe6bf</fill-color>
+    <fill-color>#b3ffe6bf</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C30</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C0</line-style>
     <valid>true</valid>
     <visible>true</visible>
@@ -2561,10 +2561,10 @@
   </properties>
   <properties>
     <frame-color>#ff8000</frame-color>
-    <fill-color>#ff8000</fill-color>
+    <fill-color>#b3ff8000</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C31</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C8</line-style>
     <valid>true</valid>
     <visible>true</visible>
@@ -2609,10 +2609,10 @@
   </properties>
   <properties>
     <frame-color>#ff8000</frame-color>
-    <fill-color>#ff8000</fill-color>
+    <fill-color>#b3ff8000</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C32</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C0</line-style>
     <valid>true</valid>
     <visible>true</visible>
@@ -3364,7 +3364,7 @@
     <fill-color>#ff0000</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C11</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C3</line-style>
     <valid>true</valid>
     <visible>true</visible>
@@ -3380,7 +3380,7 @@
     <fill-color>#ff0000</fill-color>
     <frame-brightness>0</frame-brightness>
     <fill-brightness>0</fill-brightness>
-    <dither-pattern>C11</dither-pattern>
+    <dither-pattern>I1</dither-pattern>
     <line-style>C3</line-style>
     <valid>true</valid>
     <visible>true</visible>

--- a/scripts/render_stdcells.py
+++ b/scripts/render_stdcells.py
@@ -23,6 +23,8 @@ def render_cells():
     # In headless mode, this requires xvfb-run
     view = pya.LayoutView()
     view.set_config('background-color', '#ffffff')
+    view.set_config('grid-visible', 'false')
+    view.set_config('text-visible', 'false')
     view.show_layout(layout, False)
 
     if os.path.exists(lyp_path):
@@ -46,7 +48,7 @@ def render_cells():
 
         # Save image
         image_path = os.path.join(output_dir, f"{cell_name}.png")
-        view.save_image(image_path, 800, 600)
+        view.save_image(image_path, 2000, 1500)
 
     print("Rendering complete.")
 

--- a/update_lyp.py
+++ b/update_lyp.py
@@ -1,0 +1,86 @@
+import xml.etree.ElementTree as ET
+import os
+
+lyp_path = 'ihp-sg13g2/libs.tech/klayout/tech/sg13g2.lyp'
+tree = ET.parse(lyp_path)
+root = tree.getroot()
+
+# IHP Standard Colors with Alpha (70% opacity = b3)
+alpha = 'b3'
+color_map = {
+    'Activ.drawing': f'#{alpha}00ff00',
+    'GatPoly.drawing': f'#{alpha}bf4026',
+    'Metal1.drawing': f'#{alpha}39bfff',
+    'Metal2.drawing': f'#{alpha}ccccd9',
+    'Metal3.drawing': f'#{alpha}d80000',
+    'Metal4.drawing': f'#{alpha}93e837',
+    'Metal5.drawing': f'#{alpha}dcd146',
+    'TopMetal1.drawing': f'#{alpha}ffe6bf',
+    'TopMetal2.drawing': f'#{alpha}ff8000',
+    'Cont.drawing': f'#{alpha}00ffff',
+    'Via1.drawing': f'#{alpha}ccccff',
+    'Via2.drawing': f'#{alpha}ff3736',
+    'Via3.drawing': f'#{alpha}9ba940',
+    'Via4.drawing': f'#{alpha}deac5e',
+    'TopVia1.drawing': f'#{alpha}ffe6bf',
+    'TopVia2.drawing': f'#{alpha}ff8000',
+    'NWell.drawing': f'#66268c6b',
+    'pSD.drawing': f'#66ccb899',
+    'nSD.drawing': f'#6600cc66',
+}
+
+target_layers = list(color_map.keys())
+
+for prop in root.findall('properties'):
+    name_elem = prop.find('name')
+    if name_elem is not None and name_elem.text in target_layers:
+        name = name_elem.text
+
+        dither = prop.find('dither-pattern')
+        if dither is not None:
+            dither.text = 'I1'
+
+        fill_color = prop.find('fill-color')
+        if fill_color is not None:
+            fill_color.text = color_map[name]
+
+        frame_color = prop.find('frame-color')
+        if frame_color is not None:
+            frame_color.text = '#' + color_map[name][3:]
+
+        transparent = prop.find('transparent')
+        if transparent is not None:
+            transparent.text = 'false'
+
+# Ensure Substrate.drawing is visible if it was hidden, but keep it white
+for prop in root.findall('properties'):
+    name_elem = prop.find('name')
+    if name_elem is not None and name_elem.text == 'Substrate.drawing':
+        visible = prop.find('visible')
+        if visible is not None:
+            visible.text = 'true'
+
+xml_str = ET.tostring(root, encoding='unicode')
+
+header = """<?xml version='1.0' encoding='UTF-8'?>
+<!--
+ Copyright 2024 IHP PDK Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+"""
+
+with open(lyp_path, 'w') as f:
+    f.write(header)
+    f.write(xml_str)
+    f.write('\n')


### PR DESCRIPTION
Adjusted the GDS/LEF rendering color scheme to match a modern IHP palette. 
Key changes:
- In `scripts/render_stdcells.py`, disabled grid and text visibility for cleaner output, and increased resolution to 2000x1500.
- In `ihp-sg13g2/libs.tech/klayout/tech/sg13g2.lyp`, updated drawing layers to use solid fills instead of stipples and added alpha-channel transparency for better overlap visualization.
- Restored the license header in the .lyp file which was accidentally removed during XML processing.

Fixes #33

---
*PR created automatically by Jules for task [5568404227885932727](https://jules.google.com/task/5568404227885932727) started by @chatelao*