### PR TITLE
Implement High-Level Symbol Generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,7 +196,8 @@ cliff*toml
 
 # Generated documentation artifacts
 rendered_cells/
-docs/_static/images/*.png
+docs/_static/images/
+docs/_static/symbols/
 docs/libraries/sg13g2_stdcell/cells/
 
 # Virtual environments

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,11 +82,11 @@ This roadmap outlines the automated generation processes for documentation, tool
 - [x] 11.5 Embed generated SVG schematics into the Sphinx-based cell documentation pages.
 
 ## 12. High-Level Symbol Generation
-- [ ] 12.1 Deploy the `Symbolator` utility for macroscopic I/O port interface rendering.
-- [ ] 12.2 Parse Verilog module headers to automatically define symbol pins and labels.
-- [ ] 12.3 Generate clean, rectangular block symbols for every standard cell in the library.
-- [ ] 12.4 Validate symbol parity with the underlying HDL source code and pin definitions.
-- [ ] 12.5 Integrate `Symbolator` output into the individual cell datasheets.
+- [x] 12.1 Deploy the `Symbolator` utility for macroscopic I/O port interface rendering.
+- [x] 12.2 Parse Verilog module headers to automatically define symbol pins and labels.
+- [x] 12.3 Generate clean, rectangular block symbols for every standard cell in the library.
+- [x] 12.4 Validate symbol parity with the underlying HDL source code and pin definitions.
+- [x] 12.5 Integrate `Symbolator` output into the individual cell datasheets.
 
 ## 13. Physical Verification and Netlist-Driven LVS
 - [ ] 13.1 Use Magic for high-accuracy parasitic and device extraction from GDSII layouts.

--- a/docs/_static/symbols/sg13g2_a21o_1.svg
+++ b/docs/_static/symbols/sg13g2_a21o_1.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A2</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B1</text>
+</g>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_a21o_2.svg
+++ b/docs/_static/symbols/sg13g2_a21o_2.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A2</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B1</text>
+</g>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_a21oi_1.svg
+++ b/docs/_static/symbols/sg13g2_a21oi_1.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A2</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B1</text>
+</g>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_a21oi_2.svg
+++ b/docs/_static/symbols/sg13g2_a21oi_2.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A2</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B1</text>
+</g>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_a221oi_1.svg
+++ b/docs/_static/symbols/sg13g2_a221oi_1.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="111" height="121" viewBox="-25 -20 111.0 121.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="110.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A2</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B1</text>
+</g>
+<g transform="translate(0,60)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B2</text>
+</g>
+<g transform="translate(0,80)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C1</text>
+</g>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="108.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_a22oi_1.svg
+++ b/docs/_static/symbols/sg13g2_a22oi_1.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="111" height="101" viewBox="-25 -20 111.0 101.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A2</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B1</text>
+</g>
+<g transform="translate(0,60)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B2</text>
+</g>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_and2_1.svg
+++ b/docs/_static/symbols/sg13g2_and2_1.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_and2_2.svg
+++ b/docs/_static/symbols/sg13g2_and2_2.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_and3_1.svg
+++ b/docs/_static/symbols/sg13g2_and3_1.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_and3_2.svg
+++ b/docs/_static/symbols/sg13g2_and3_2.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_and4_1.svg
+++ b/docs/_static/symbols/sg13g2_and4_1.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+</g>
+<g transform="translate(0,60)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_and4_2.svg
+++ b/docs/_static/symbols/sg13g2_and4_2.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+</g>
+<g transform="translate(0,60)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_antennanp.svg
+++ b/docs/_static/symbols/sg13g2_antennanp.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="71" height="41" viewBox="-25 -20 71.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_buf_1.svg
+++ b/docs/_static/symbols/sg13g2_buf_1.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_buf_16.svg
+++ b/docs/_static/symbols/sg13g2_buf_16.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_buf_2.svg
+++ b/docs/_static/symbols/sg13g2_buf_2.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_buf_4.svg
+++ b/docs/_static/symbols/sg13g2_buf_4.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_buf_8.svg
+++ b/docs/_static/symbols/sg13g2_buf_8.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_decap_4.svg
+++ b/docs/_static/symbols/sg13g2_decap_4.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
+<style type="text/css">
+<![CDATA[
+
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-5" y="-5" width="100%" height="100%" fill="white"/></svg>

--- a/docs/_static/symbols/sg13g2_decap_8.svg
+++ b/docs/_static/symbols/sg13g2_decap_8.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
+<style type="text/css">
+<![CDATA[
+
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-5" y="-5" width="100%" height="100%" fill="white"/></svg>

--- a/docs/_static/symbols/sg13g2_dfrbp_1.svg
+++ b/docs/_static/symbols/sg13g2_dfrbp_1.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+</g>
+<g transform="translate(100.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+</g>
+<g transform="translate(100.0,20)">
+<line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q_N</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_dfrbp_2.svg
+++ b/docs/_static/symbols/sg13g2_dfrbp_2.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+</g>
+<g transform="translate(100.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+</g>
+<g transform="translate(100.0,20)">
+<line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q_N</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_dfrbpq_1.svg
+++ b/docs/_static/symbols/sg13g2_dfrbpq_1.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+</g>
+<g transform="translate(100.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_dfrbpq_2.svg
+++ b/docs/_static/symbols/sg13g2_dfrbpq_2.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+</g>
+<g transform="translate(100.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_dlhq_1.svg
+++ b/docs/_static/symbols/sg13g2_dlhq_1.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">GATE</text>
+</g>
+<g transform="translate(80.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_dlhr_1.svg
+++ b/docs/_static/symbols/sg13g2_dlhr_1.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">GATE</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+</g>
+<g transform="translate(100.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+</g>
+<g transform="translate(100.0,20)">
+<line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q_N</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_dlhrq_1.svg
+++ b/docs/_static/symbols/sg13g2_dlhrq_1.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">GATE</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+</g>
+<g transform="translate(100.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_dllr_1.svg
+++ b/docs/_static/symbols/sg13g2_dllr_1.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">GATE_N</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+</g>
+<g transform="translate(100.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+</g>
+<g transform="translate(100.0,20)">
+<line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q_N</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_dllrq_1.svg
+++ b/docs/_static/symbols/sg13g2_dllrq_1.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">GATE_N</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+</g>
+<g transform="translate(100.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_dlygate4sd1_1.svg
+++ b/docs/_static/symbols/sg13g2_dlygate4sd1_1.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_dlygate4sd2_1.svg
+++ b/docs/_static/symbols/sg13g2_dlygate4sd2_1.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_dlygate4sd3_1.svg
+++ b/docs/_static/symbols/sg13g2_dlygate4sd3_1.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_ebufn_2.svg
+++ b/docs/_static/symbols/sg13g2_ebufn_2.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">TE_B</text>
+</g>
+<g transform="translate(80.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Z</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_ebufn_4.svg
+++ b/docs/_static/symbols/sg13g2_ebufn_4.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">TE_B</text>
+</g>
+<g transform="translate(80.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Z</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_ebufn_8.svg
+++ b/docs/_static/symbols/sg13g2_ebufn_8.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">TE_B</text>
+</g>
+<g transform="translate(80.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Z</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_einvn_2.svg
+++ b/docs/_static/symbols/sg13g2_einvn_2.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">TE_B</text>
+</g>
+<g transform="translate(80.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Z</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_einvn_4.svg
+++ b/docs/_static/symbols/sg13g2_einvn_4.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">TE_B</text>
+</g>
+<g transform="translate(80.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Z</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_einvn_8.svg
+++ b/docs/_static/symbols/sg13g2_einvn_8.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">TE_B</text>
+</g>
+<g transform="translate(80.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Z</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_fill_1.svg
+++ b/docs/_static/symbols/sg13g2_fill_1.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
+<style type="text/css">
+<![CDATA[
+
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-5" y="-5" width="100%" height="100%" fill="white"/></svg>

--- a/docs/_static/symbols/sg13g2_fill_2.svg
+++ b/docs/_static/symbols/sg13g2_fill_2.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
+<style type="text/css">
+<![CDATA[
+
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-5" y="-5" width="100%" height="100%" fill="white"/></svg>

--- a/docs/_static/symbols/sg13g2_fill_4.svg
+++ b/docs/_static/symbols/sg13g2_fill_4.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
+<style type="text/css">
+<![CDATA[
+
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-5" y="-5" width="100%" height="100%" fill="white"/></svg>

--- a/docs/_static/symbols/sg13g2_fill_8.svg
+++ b/docs/_static/symbols/sg13g2_fill_8.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
+<style type="text/css">
+<![CDATA[
+
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-5" y="-5" width="100%" height="100%" fill="white"/></svg>

--- a/docs/_static/symbols/sg13g2_inv_1.svg
+++ b/docs/_static/symbols/sg13g2_inv_1.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_inv_16.svg
+++ b/docs/_static/symbols/sg13g2_inv_16.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_inv_2.svg
+++ b/docs/_static/symbols/sg13g2_inv_2.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_inv_4.svg
+++ b/docs/_static/symbols/sg13g2_inv_4.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_inv_8.svg
+++ b/docs/_static/symbols/sg13g2_inv_8.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_lgcp_1.svg
+++ b/docs/_static/symbols/sg13g2_lgcp_1.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="151" height="61" viewBox="-25 -20 151.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">GATE</text>
+</g>
+<g transform="translate(100.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">GCLK</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_mux2_1.svg
+++ b/docs/_static/symbols/sg13g2_mux2_1.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A0</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">S</text>
+</g>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_mux2_2.svg
+++ b/docs/_static/symbols/sg13g2_mux2_2.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A0</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">S</text>
+</g>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_mux4_1.svg
+++ b/docs/_static/symbols/sg13g2_mux4_1.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="111" height="141" viewBox="-25 -20 111.0 141.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="130.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A0</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A2</text>
+</g>
+<g transform="translate(0,60)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A3</text>
+</g>
+<g transform="translate(0,80)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">S0</text>
+</g>
+<g transform="translate(0,100)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">S1</text>
+</g>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="128.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_nand2_1.svg
+++ b/docs/_static/symbols/sg13g2_nand2_1.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_nand2_2.svg
+++ b/docs/_static/symbols/sg13g2_nand2_2.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_nand2b_1.svg
+++ b/docs/_static/symbols/sg13g2_nand2b_1.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="111" height="61" viewBox="-25 -20 111.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A_N</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_nand2b_2.svg
+++ b/docs/_static/symbols/sg13g2_nand2b_2.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="111" height="61" viewBox="-25 -20 111.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A_N</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_nand3_1.svg
+++ b/docs/_static/symbols/sg13g2_nand3_1.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_nand3b_1.svg
+++ b/docs/_static/symbols/sg13g2_nand3b_1.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A_N</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+</g>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_nand4_1.svg
+++ b/docs/_static/symbols/sg13g2_nand4_1.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+</g>
+<g transform="translate(0,60)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_nor2_1.svg
+++ b/docs/_static/symbols/sg13g2_nor2_1.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_nor2_2.svg
+++ b/docs/_static/symbols/sg13g2_nor2_2.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_nor2b_1.svg
+++ b/docs/_static/symbols/sg13g2_nor2b_1.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="111" height="61" viewBox="-25 -20 111.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B_N</text>
+</g>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_nor2b_2.svg
+++ b/docs/_static/symbols/sg13g2_nor2b_2.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="111" height="61" viewBox="-25 -20 111.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B_N</text>
+</g>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_nor3_1.svg
+++ b/docs/_static/symbols/sg13g2_nor3_1.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_nor3_2.svg
+++ b/docs/_static/symbols/sg13g2_nor3_2.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_nor4_1.svg
+++ b/docs/_static/symbols/sg13g2_nor4_1.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+</g>
+<g transform="translate(0,60)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_nor4_2.svg
+++ b/docs/_static/symbols/sg13g2_nor4_2.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+</g>
+<g transform="translate(0,60)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_o21ai_1.svg
+++ b/docs/_static/symbols/sg13g2_o21ai_1.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A2</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B1</text>
+</g>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_or2_1.svg
+++ b/docs/_static/symbols/sg13g2_or2_1.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_or2_2.svg
+++ b/docs/_static/symbols/sg13g2_or2_2.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_or3_1.svg
+++ b/docs/_static/symbols/sg13g2_or3_1.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_or3_2.svg
+++ b/docs/_static/symbols/sg13g2_or3_2.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_or4_1.svg
+++ b/docs/_static/symbols/sg13g2_or4_1.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+</g>
+<g transform="translate(0,60)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_or4_2.svg
+++ b/docs/_static/symbols/sg13g2_or4_2.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+</g>
+<g transform="translate(0,60)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_sdfbbp_1.svg
+++ b/docs/_static/symbols/sg13g2_sdfbbp_1.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="151" height="141" viewBox="-25 -20 151.0 141.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="130.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+</g>
+<g transform="translate(0,60)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCD</text>
+</g>
+<g transform="translate(0,80)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCE</text>
+</g>
+<g transform="translate(0,100)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SET_B</text>
+</g>
+<g transform="translate(100.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+</g>
+<g transform="translate(100.0,20)">
+<line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q_N</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="128.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_sdfrbp_1.svg
+++ b/docs/_static/symbols/sg13g2_sdfrbp_1.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="151" height="121" viewBox="-25 -20 151.0 121.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="110.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+</g>
+<g transform="translate(0,60)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCD</text>
+</g>
+<g transform="translate(0,80)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCE</text>
+</g>
+<g transform="translate(100.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+</g>
+<g transform="translate(100.0,20)">
+<line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q_N</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="108.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_sdfrbp_2.svg
+++ b/docs/_static/symbols/sg13g2_sdfrbp_2.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="151" height="121" viewBox="-25 -20 151.0 121.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="110.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+</g>
+<g transform="translate(0,60)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCD</text>
+</g>
+<g transform="translate(0,80)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCE</text>
+</g>
+<g transform="translate(100.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+</g>
+<g transform="translate(100.0,20)">
+<line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q_N</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="108.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_sdfrbpq_1.svg
+++ b/docs/_static/symbols/sg13g2_sdfrbpq_1.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="151" height="121" viewBox="-25 -20 151.0 121.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="110.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+</g>
+<g transform="translate(0,60)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCD</text>
+</g>
+<g transform="translate(0,80)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCE</text>
+</g>
+<g transform="translate(100.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="108.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_sdfrbpq_2.svg
+++ b/docs/_static/symbols/sg13g2_sdfrbpq_2.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="151" height="121" viewBox="-25 -20 151.0 121.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="110.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+</g>
+<g transform="translate(0,60)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCD</text>
+</g>
+<g transform="translate(0,80)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCE</text>
+</g>
+<g transform="translate(100.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="108.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_sighold.svg
+++ b/docs/_static/symbols/sg13g2_sighold.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="71" height="41" viewBox="-5 -20 71.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="arrow_fwd" markerWidth="8.0" markerHeight="8.0" viewBox="0 0 8.0 8.0" refX="3.2" refY="4.0" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(-0.0,4.0)"><path d="M 0 -4 C 2 -1, 2 1, 0 4 L 8 0 z" stroke="none" fill="#000000"/>
+</g>
+</marker>
+<marker id="arrow_back" markerWidth="8.0" markerHeight="8.0" viewBox="0 0 8.0 8.0" refX="4.8" refY="4.0" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(8.0,4.0)"><path d="M 0 -4 C -2 -1, -2 1, 0 4 L -8 0 z" stroke="none" fill="#000000"/>
+</g>
+</marker>
+</defs>
+<rect x="-5" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(40.0,0)">
+<line x1="16.16" y1="4.702643708725836e-16" x2="3.84" y2="-4.702643708725836e-16" stroke="#000000" fill="none" stroke-width="1" marker-start="url(#arrow_back)" marker-end="url(#arrow_fwd)"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">SH</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_slgcp_1.svg
+++ b/docs/_static/symbols/sg13g2_slgcp_1.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">GATE</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+</g>
+<g transform="translate(0,40)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCE</text>
+</g>
+<g transform="translate(100.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">GCLK</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_tiehi.svg
+++ b/docs/_static/symbols/sg13g2_tiehi.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="41" viewBox="-5 -20 91.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-5" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">L_HI</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_tielo.svg
+++ b/docs/_static/symbols/sg13g2_tielo.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="41" viewBox="-5 -20 91.0 41.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-5" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(60.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">L_LO</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="58.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_xnor2_1.svg
+++ b/docs/_static/symbols/sg13g2_xnor2_1.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_xor2_1.svg
+++ b/docs/_static/symbols/sg13g2_xor2_1.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created by Symbolator http://kevinpt.github.io/symbolator -->
+<svg xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+xml:space="preserve"
+width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+<style type="text/css">
+<![CDATA[
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.label {fill:#000;
+  text-anchor:middle;
+  font-size:16pt; font-weight:bold; font-family:Sans;}
+.link {fill: #0D47A1;}
+.link:hover {fill: #0D47A1; text-decoration:underline;}
+.link:visited {fill: #4A148C;}
+]]>
+</style>
+<defs>
+
+</defs>
+<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(0,0)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+</g>
+<g transform="translate(0,20)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+</g>
+<g transform="translate(40.0,0)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21o_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21o_1.rst
@@ -10,6 +10,15 @@ sg13g2_a21o_1
 -  **Inputs**:  3 (A1, A2, B1)
 -  **Outputs**: 1 (X)
 
+sg13g2_a21o_1 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_a21o_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_a21o_1 symbol
+
 sg13g2_a21o_1 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21o_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21o_2.rst
@@ -10,6 +10,15 @@ sg13g2_a21o_2
 -  **Inputs**:  3 (A1, A2, B1)
 -  **Outputs**: 1 (X)
 
+sg13g2_a21o_2 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_a21o_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_a21o_2 symbol
+
 sg13g2_a21o_2 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21oi_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21oi_1.rst
@@ -10,6 +10,15 @@ sg13g2_a21oi_1
 -  **Inputs**:  3 (A1, A2, B1)
 -  **Outputs**: 1 (Y)
 
+sg13g2_a21oi_1 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_a21oi_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_a21oi_1 symbol
+
 sg13g2_a21oi_1 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21oi_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a21oi_2.rst
@@ -10,6 +10,15 @@ sg13g2_a21oi_2
 -  **Inputs**:  3 (A1, A2, B1)
 -  **Outputs**: 1 (Y)
 
+sg13g2_a21oi_2 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_a21oi_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_a21oi_2 symbol
+
 sg13g2_a21oi_2 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a221oi_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a221oi_1.rst
@@ -10,6 +10,15 @@ sg13g2_a221oi_1
 -  **Inputs**:  5 (A1, A2, B1, B2, C1)
 -  **Outputs**: 1 (Y)
 
+sg13g2_a221oi_1 symbol
+----------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_a221oi_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_a221oi_1 symbol
+
 sg13g2_a221oi_1 schematic
 -------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_a22oi_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_a22oi_1.rst
@@ -10,6 +10,15 @@ sg13g2_a22oi_1
 -  **Inputs**:  4 (A1, A2, B1, B2)
 -  **Outputs**: 1 (Y)
 
+sg13g2_a22oi_1 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_a22oi_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_a22oi_1 symbol
+
 sg13g2_a22oi_1 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and2_1.rst
@@ -10,6 +10,15 @@ sg13g2_and2_1
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (X)
 
+sg13g2_and2_1 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_and2_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_and2_1 symbol
+
 sg13g2_and2_1 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and2_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and2_2.rst
@@ -10,6 +10,15 @@ sg13g2_and2_2
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (X)
 
+sg13g2_and2_2 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_and2_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_and2_2 symbol
+
 sg13g2_and2_2 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and3_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and3_1.rst
@@ -10,6 +10,15 @@ sg13g2_and3_1
 -  **Inputs**:  3 (A, B, C)
 -  **Outputs**: 1 (X)
 
+sg13g2_and3_1 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_and3_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_and3_1 symbol
+
 sg13g2_and3_1 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and3_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and3_2.rst
@@ -10,6 +10,15 @@ sg13g2_and3_2
 -  **Inputs**:  3 (A, B, C)
 -  **Outputs**: 1 (X)
 
+sg13g2_and3_2 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_and3_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_and3_2 symbol
+
 sg13g2_and3_2 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and4_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and4_1.rst
@@ -10,6 +10,15 @@ sg13g2_and4_1
 -  **Inputs**:  4 (A, B, C, D)
 -  **Outputs**: 1 (X)
 
+sg13g2_and4_1 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_and4_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_and4_1 symbol
+
 sg13g2_and4_1 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_and4_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_and4_2.rst
@@ -10,6 +10,15 @@ sg13g2_and4_2
 -  **Inputs**:  4 (A, B, C, D)
 -  **Outputs**: 1 (X)
 
+sg13g2_and4_2 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_and4_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_and4_2 symbol
+
 sg13g2_and4_2 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_antennanp.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_antennanp.rst
@@ -10,6 +10,15 @@ Antenna effect protection cell (gate charge) at manufacture, P-diode in N-Well, 
 -  **Inputs**:  1 (A)
 -  **Outputs**: 0 ()
 
+sg13g2_antennanp symbol
+-----------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_antennanp.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_antennanp symbol
+
 sg13g2_antennanp schematic
 --------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_1.rst
@@ -10,6 +10,15 @@ Buffer drive strength 1
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (X)
 
+sg13g2_buf_1 symbol
+-------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_buf_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_buf_1 symbol
+
 sg13g2_buf_1 schematic
 ----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_16.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_16.rst
@@ -10,6 +10,15 @@ Buffer drive strength 16
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (X)
 
+sg13g2_buf_16 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_buf_16.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_buf_16 symbol
+
 sg13g2_buf_16 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_2.rst
@@ -10,6 +10,15 @@ Buffer drive strength 2
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (X)
 
+sg13g2_buf_2 symbol
+-------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_buf_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_buf_2 symbol
+
 sg13g2_buf_2 schematic
 ----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_4.rst
@@ -10,6 +10,15 @@ Buffer drive strength 4
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (X)
 
+sg13g2_buf_4 symbol
+-------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_buf_4.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_buf_4 symbol
+
 sg13g2_buf_4 schematic
 ----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_buf_8.rst
@@ -10,6 +10,15 @@ Buffer drive strength 8
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (X)
 
+sg13g2_buf_8 symbol
+-------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_buf_8.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_buf_8 symbol
+
 sg13g2_buf_8 schematic
 ----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_decap_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_decap_4.rst
@@ -10,6 +10,15 @@ Decoupling capasitance filler cell
 -  **Inputs**:  0 ()
 -  **Outputs**: 0 ()
 
+sg13g2_decap_4 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_decap_4.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_decap_4 symbol
+
 sg13g2_decap_4 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_decap_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_decap_8.rst
@@ -10,6 +10,15 @@ Decoupling capasitance filler cell
 -  **Inputs**:  0 ()
 -  **Outputs**: 0 ()
 
+sg13g2_decap_8 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_decap_8.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_decap_8 symbol
+
 sg13g2_decap_8 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbp_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbp_1.rst
@@ -10,6 +10,15 @@ Posedge Two-Outputs Q and Q_N D-Flip-Flop with Low-Active Reset
 -  **Inputs**:  3 (CLK, D, RESET_B)
 -  **Outputs**: 2 (Q, Q_N)
 
+sg13g2_dfrbp_1 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_dfrbp_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_dfrbp_1 symbol
+
 sg13g2_dfrbp_1 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbp_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbp_2.rst
@@ -10,6 +10,15 @@ Posedge Two-Outputs Q and Q_N D-Flip-Flop with Low-Active Reset
 -  **Inputs**:  3 (CLK, D, RESET_B)
 -  **Outputs**: 2 (Q, Q_N)
 
+sg13g2_dfrbp_2 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_dfrbp_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_dfrbp_2 symbol
+
 sg13g2_dfrbp_2 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbpq_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbpq_1.rst
@@ -10,6 +10,15 @@ Posedge Single-Output Q D-Flip-Flop with Low-Active Reset
 -  **Inputs**:  3 (CLK, D, RESET_B)
 -  **Outputs**: 1 (Q)
 
+sg13g2_dfrbpq_1 symbol
+----------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_dfrbpq_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_dfrbpq_1 symbol
+
 sg13g2_dfrbpq_1 schematic
 -------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbpq_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dfrbpq_2.rst
@@ -10,6 +10,15 @@ Posedge Single-Output Q D-Flip-Flop with Low-Active Reset
 -  **Inputs**:  3 (CLK, D, RESET_B)
 -  **Outputs**: 1 (Q)
 
+sg13g2_dfrbpq_2 symbol
+----------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_dfrbpq_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_dfrbpq_2 symbol
+
 sg13g2_dfrbpq_2 schematic
 -------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhq_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhq_1.rst
@@ -10,6 +10,15 @@ High-Active GATE Single-Output Q D-latch
 -  **Inputs**:  2 (D, GATE)
 -  **Outputs**: 1 (Q)
 
+sg13g2_dlhq_1 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_dlhq_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_dlhq_1 symbol
+
 sg13g2_dlhq_1 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhr_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhr_1.rst
@@ -10,6 +10,15 @@ High-Active GATE Two-Outputs Q Q_N D-latch with Low-Active Reset
 -  **Inputs**:  3 (D, GATE, RESET_B)
 -  **Outputs**: 2 (Q, Q_N)
 
+sg13g2_dlhr_1 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_dlhr_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_dlhr_1 symbol
+
 sg13g2_dlhr_1 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhrq_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlhrq_1.rst
@@ -10,6 +10,15 @@ High-Active Gate Single-Output Q D-latch with Low-Active Reset
 -  **Inputs**:  3 (D, GATE, RESET_B)
 -  **Outputs**: 1 (Q)
 
+sg13g2_dlhrq_1 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_dlhrq_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_dlhrq_1 symbol
+
 sg13g2_dlhrq_1 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dllr_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dllr_1.rst
@@ -10,6 +10,15 @@ Low-Active GATE_N Two-Outputs Q Q_N D-latch with Low-Active Reset
 -  **Inputs**:  3 (D, GATE_N, RESET_B)
 -  **Outputs**: 2 (Q, Q_N)
 
+sg13g2_dllr_1 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_dllr_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_dllr_1 symbol
+
 sg13g2_dllr_1 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dllrq_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dllrq_1.rst
@@ -10,6 +10,15 @@ Low-Active GATE_N Single-Output Q D-latch with Low-Active Reset
 -  **Inputs**:  3 (D, GATE_N, RESET_B)
 -  **Outputs**: 1 (Q)
 
+sg13g2_dllrq_1 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_dllrq_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_dllrq_1 symbol
+
 sg13g2_dllrq_1 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd1_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd1_1.rst
@@ -10,6 +10,15 @@ Delay Cell, typical 0.4 ns
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (X)
 
+sg13g2_dlygate4sd1_1 symbol
+---------------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_dlygate4sd1_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_dlygate4sd1_1 symbol
+
 sg13g2_dlygate4sd1_1 schematic
 ------------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd2_1.rst
@@ -10,6 +10,15 @@ Delay Cell, typical 0.45 ns
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (X)
 
+sg13g2_dlygate4sd2_1 symbol
+---------------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_dlygate4sd2_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_dlygate4sd2_1 symbol
+
 sg13g2_dlygate4sd2_1 schematic
 ------------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd3_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_dlygate4sd3_1.rst
@@ -10,6 +10,15 @@ Delay Cell, typical 0.7 ns
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (X)
 
+sg13g2_dlygate4sd3_1 symbol
+---------------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_dlygate4sd3_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_dlygate4sd3_1 symbol
+
 sg13g2_dlygate4sd3_1 schematic
 ------------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_2.rst
@@ -10,6 +10,15 @@ Tristate Buffer with Low-Active Enable TE_B
 -  **Inputs**:  2 (A, TE_B)
 -  **Outputs**: 1 (Z)
 
+sg13g2_ebufn_2 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_ebufn_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_ebufn_2 symbol
+
 sg13g2_ebufn_2 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_4.rst
@@ -10,6 +10,15 @@ Tristate Buffer with Low-Active Enable TE_B
 -  **Inputs**:  2 (A, TE_B)
 -  **Outputs**: 1 (Z)
 
+sg13g2_ebufn_4 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_ebufn_4.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_ebufn_4 symbol
+
 sg13g2_ebufn_4 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_ebufn_8.rst
@@ -10,6 +10,15 @@ Tristate Buffer with Low-Active Enable TE_B
 -  **Inputs**:  2 (A, TE_B)
 -  **Outputs**: 1 (Z)
 
+sg13g2_ebufn_8 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_ebufn_8.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_ebufn_8 symbol
+
 sg13g2_ebufn_8 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_2.rst
@@ -10,6 +10,15 @@ Tristate Inverter with Low-Active Enable TE_B
 -  **Inputs**:  2 (A, TE_B)
 -  **Outputs**: 1 (Z)
 
+sg13g2_einvn_2 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_einvn_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_einvn_2 symbol
+
 sg13g2_einvn_2 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_4.rst
@@ -10,6 +10,15 @@ Tristate Inverter with Low-Active Enable TE_B
 -  **Inputs**:  2 (A, TE_B)
 -  **Outputs**: 1 (Z)
 
+sg13g2_einvn_4 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_einvn_4.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_einvn_4 symbol
+
 sg13g2_einvn_4 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_einvn_8.rst
@@ -10,6 +10,15 @@ Tristate Inverter with Low-Active Enable TE_B
 -  **Inputs**:  2 (A, TE_B)
 -  **Outputs**: 1 (Z)
 
+sg13g2_einvn_8 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_einvn_8.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_einvn_8 symbol
+
 sg13g2_einvn_8 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_1.rst
@@ -10,6 +10,15 @@ Filler 1 Track Width
 -  **Inputs**:  0 ()
 -  **Outputs**: 0 ()
 
+sg13g2_fill_1 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_fill_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_fill_1 symbol
+
 sg13g2_fill_1 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_2.rst
@@ -10,6 +10,15 @@ Filler 2 Tracks Width
 -  **Inputs**:  0 ()
 -  **Outputs**: 0 ()
 
+sg13g2_fill_2 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_fill_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_fill_2 symbol
+
 sg13g2_fill_2 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_4.rst
@@ -10,6 +10,15 @@ Filler 4 Tracks Width
 -  **Inputs**:  0 ()
 -  **Outputs**: 0 ()
 
+sg13g2_fill_4 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_fill_4.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_fill_4 symbol
+
 sg13g2_fill_4 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_fill_8.rst
@@ -10,6 +10,15 @@ Filler 8 Tracks Width
 -  **Inputs**:  0 ()
 -  **Outputs**: 0 ()
 
+sg13g2_fill_8 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_fill_8.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_fill_8 symbol
+
 sg13g2_fill_8 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_1.rst
@@ -10,6 +10,15 @@ Inverter
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (Y)
 
+sg13g2_inv_1 symbol
+-------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_inv_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_inv_1 symbol
+
 sg13g2_inv_1 schematic
 ----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_16.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_16.rst
@@ -10,6 +10,15 @@ Inverter
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (Y)
 
+sg13g2_inv_16 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_inv_16.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_inv_16 symbol
+
 sg13g2_inv_16 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_2.rst
@@ -10,6 +10,15 @@ Inverter
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (Y)
 
+sg13g2_inv_2 symbol
+-------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_inv_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_inv_2 symbol
+
 sg13g2_inv_2 schematic
 ----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_4.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_4.rst
@@ -10,6 +10,15 @@ Inverter
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (Y)
 
+sg13g2_inv_4 symbol
+-------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_inv_4.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_inv_4 symbol
+
 sg13g2_inv_4 schematic
 ----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_8.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_inv_8.rst
@@ -10,6 +10,15 @@ Inverter
 -  **Inputs**:  1 (A)
 -  **Outputs**: 1 (Y)
 
+sg13g2_inv_8 symbol
+-------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_inv_8.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_inv_8 symbol
+
 sg13g2_inv_8 schematic
 ----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_lgcp_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_lgcp_1.rst
@@ -10,6 +10,15 @@ Posedge Clock Gating cell, Low Latch Enable
 -  **Inputs**:  2 (CLK, GATE)
 -  **Outputs**: 1 (GCLK)
 
+sg13g2_lgcp_1 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_lgcp_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_lgcp_1 symbol
+
 sg13g2_lgcp_1 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux2_1.rst
@@ -10,6 +10,15 @@ Multiplexer from 2 to 1
 -  **Inputs**:  3 (A0, A1, S)
 -  **Outputs**: 1 (X)
 
+sg13g2_mux2_1 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_mux2_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_mux2_1 symbol
+
 sg13g2_mux2_1 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux2_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux2_2.rst
@@ -10,6 +10,15 @@ Multiplexer from 2 to 1
 -  **Inputs**:  3 (A0, A1, S)
 -  **Outputs**: 1 (X)
 
+sg13g2_mux2_2 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_mux2_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_mux2_2 symbol
+
 sg13g2_mux2_2 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux4_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_mux4_1.rst
@@ -10,6 +10,15 @@ Multiplexer from 4 to 1
 -  **Inputs**:  6 (A0, A1, A2, A3, S0, S1)
 -  **Outputs**: 1 (X)
 
+sg13g2_mux4_1 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_mux4_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_mux4_1 symbol
+
 sg13g2_mux4_1 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2_1.rst
@@ -10,6 +10,15 @@ sg13g2_nand2_1
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nand2_1 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_nand2_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_nand2_1 symbol
+
 sg13g2_nand2_1 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2_2.rst
@@ -10,6 +10,15 @@ sg13g2_nand2_2
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nand2_2 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_nand2_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_nand2_2 symbol
+
 sg13g2_nand2_2 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2b_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2b_1.rst
@@ -10,6 +10,15 @@ sg13g2_nand2b_1
 -  **Inputs**:  2 (A_N, B)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nand2b_1 symbol
+----------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_nand2b_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_nand2b_1 symbol
+
 sg13g2_nand2b_1 schematic
 -------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2b_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand2b_2.rst
@@ -10,6 +10,15 @@ sg13g2_nand2b_2
 -  **Inputs**:  2 (A_N, B)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nand2b_2 symbol
+----------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_nand2b_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_nand2b_2 symbol
+
 sg13g2_nand2b_2 schematic
 -------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand3_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand3_1.rst
@@ -10,6 +10,15 @@ sg13g2_nand3_1
 -  **Inputs**:  3 (A, B, C)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nand3_1 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_nand3_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_nand3_1 symbol
+
 sg13g2_nand3_1 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand3b_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand3b_1.rst
@@ -10,6 +10,15 @@ sg13g2_nand3b_1
 -  **Inputs**:  3 (A_N, B, C)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nand3b_1 symbol
+----------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_nand3b_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_nand3b_1 symbol
+
 sg13g2_nand3b_1 schematic
 -------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand4_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nand4_1.rst
@@ -10,6 +10,15 @@ sg13g2_nand4_1
 -  **Inputs**:  4 (A, B, C, D)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nand4_1 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_nand4_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_nand4_1 symbol
+
 sg13g2_nand4_1 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2_1.rst
@@ -10,6 +10,15 @@ sg13g2_nor2_1
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nor2_1 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_nor2_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_nor2_1 symbol
+
 sg13g2_nor2_1 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2_2.rst
@@ -10,6 +10,15 @@ sg13g2_nor2_2
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nor2_2 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_nor2_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_nor2_2 symbol
+
 sg13g2_nor2_2 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2b_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2b_1.rst
@@ -10,6 +10,15 @@ sg13g2_nor2b_1
 -  **Inputs**:  2 (A, B_N)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nor2b_1 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_nor2b_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_nor2b_1 symbol
+
 sg13g2_nor2b_1 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2b_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor2b_2.rst
@@ -10,6 +10,15 @@ sg13g2_nor2b_2
 -  **Inputs**:  2 (A, B_N)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nor2b_2 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_nor2b_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_nor2b_2 symbol
+
 sg13g2_nor2b_2 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor3_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor3_1.rst
@@ -10,6 +10,15 @@ sg13g2_nor3_1
 -  **Inputs**:  3 (A, B, C)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nor3_1 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_nor3_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_nor3_1 symbol
+
 sg13g2_nor3_1 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor3_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor3_2.rst
@@ -10,6 +10,15 @@ sg13g2_nor3_2
 -  **Inputs**:  3 (A, B, C)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nor3_2 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_nor3_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_nor3_2 symbol
+
 sg13g2_nor3_2 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor4_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor4_1.rst
@@ -10,6 +10,15 @@ sg13g2_nor4_1
 -  **Inputs**:  4 (A, B, C, D)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nor4_1 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_nor4_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_nor4_1 symbol
+
 sg13g2_nor4_1 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor4_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_nor4_2.rst
@@ -10,6 +10,15 @@ sg13g2_nor4_2
 -  **Inputs**:  4 (A, B, C, D)
 -  **Outputs**: 1 (Y)
 
+sg13g2_nor4_2 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_nor4_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_nor4_2 symbol
+
 sg13g2_nor4_2 schematic
 -----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_o21ai_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_o21ai_1.rst
@@ -10,6 +10,15 @@ sg13g2_o21ai_1
 -  **Inputs**:  3 (A1, A2, B1)
 -  **Outputs**: 1 (Y)
 
+sg13g2_o21ai_1 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_o21ai_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_o21ai_1 symbol
+
 sg13g2_o21ai_1 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or2_1.rst
@@ -10,6 +10,15 @@ sg13g2_or2_1
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (X)
 
+sg13g2_or2_1 symbol
+-------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_or2_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_or2_1 symbol
+
 sg13g2_or2_1 schematic
 ----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or2_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or2_2.rst
@@ -10,6 +10,15 @@ sg13g2_or2_2
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (X)
 
+sg13g2_or2_2 symbol
+-------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_or2_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_or2_2 symbol
+
 sg13g2_or2_2 schematic
 ----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or3_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or3_1.rst
@@ -10,6 +10,15 @@ sg13g2_or3_1
 -  **Inputs**:  3 (A, B, C)
 -  **Outputs**: 1 (X)
 
+sg13g2_or3_1 symbol
+-------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_or3_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_or3_1 symbol
+
 sg13g2_or3_1 schematic
 ----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or3_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or3_2.rst
@@ -10,6 +10,15 @@ sg13g2_or3_2
 -  **Inputs**:  3 (A, B, C)
 -  **Outputs**: 1 (X)
 
+sg13g2_or3_2 symbol
+-------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_or3_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_or3_2 symbol
+
 sg13g2_or3_2 schematic
 ----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or4_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or4_1.rst
@@ -10,6 +10,15 @@ sg13g2_or4_1
 -  **Inputs**:  4 (A, B, C, D)
 -  **Outputs**: 1 (X)
 
+sg13g2_or4_1 symbol
+-------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_or4_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_or4_1 symbol
+
 sg13g2_or4_1 schematic
 ----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_or4_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_or4_2.rst
@@ -10,6 +10,15 @@ sg13g2_or4_2
 -  **Inputs**:  4 (A, B, C, D)
 -  **Outputs**: 1 (X)
 
+sg13g2_or4_2 symbol
+-------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_or4_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_or4_2 symbol
+
 sg13g2_or4_2 schematic
 ----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfbbp_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfbbp_1.rst
@@ -10,6 +10,15 @@ Posedge Two-Outputs D-Flip-Flop with Reset, Set and Scan
 -  **Inputs**:  6 (CLK, D, RESET_B, SCD, SCE, SET_B)
 -  **Outputs**: 2 (Q, Q_N)
 
+sg13g2_sdfbbp_1 symbol
+----------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_sdfbbp_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_sdfbbp_1 symbol
+
 sg13g2_sdfbbp_1 schematic
 -------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbp_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbp_1.rst
@@ -10,6 +10,15 @@ Posedge Two-Outputs Q and Q_N D-Flip-Flop with Reset and Scan
 -  **Inputs**:  5 (CLK, D, RESET_B, SCD, SCE)
 -  **Outputs**: 2 (Q, Q_N)
 
+sg13g2_sdfrbp_1 symbol
+----------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_sdfrbp_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_sdfrbp_1 symbol
+
 sg13g2_sdfrbp_1 schematic
 -------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbp_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbp_2.rst
@@ -10,6 +10,15 @@ Posedge Two-Outputs Q and Q_N D-Flip-Flop with Reset and Scan
 -  **Inputs**:  5 (CLK, D, RESET_B, SCD, SCE)
 -  **Outputs**: 2 (Q, Q_N)
 
+sg13g2_sdfrbp_2 symbol
+----------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_sdfrbp_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_sdfrbp_2 symbol
+
 sg13g2_sdfrbp_2 schematic
 -------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbpq_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbpq_1.rst
@@ -10,6 +10,15 @@ Posedge Single-Output Q D-Flip-Flop with Reset and Scan
 -  **Inputs**:  5 (CLK, D, RESET_B, SCD, SCE)
 -  **Outputs**: 1 (Q)
 
+sg13g2_sdfrbpq_1 symbol
+-----------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_sdfrbpq_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_sdfrbpq_1 symbol
+
 sg13g2_sdfrbpq_1 schematic
 --------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbpq_2.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sdfrbpq_2.rst
@@ -10,6 +10,15 @@ Posedge Single-Output Q D-Flip-Flop with Reset and Scan
 -  **Inputs**:  5 (CLK, D, RESET_B, SCD, SCE)
 -  **Outputs**: 1 (Q)
 
+sg13g2_sdfrbpq_2 symbol
+-----------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_sdfrbpq_2.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_sdfrbpq_2 symbol
+
 sg13g2_sdfrbpq_2 schematic
 --------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_sighold.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_sighold.rst
@@ -10,6 +10,15 @@ Leakage current compensator (bus holder)
 -  **Inputs**:  0 ()
 -  **Outputs**: 0 ()
 
+sg13g2_sighold symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_sighold.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_sighold symbol
+
 sg13g2_sighold schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_slgcp_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_slgcp_1.rst
@@ -10,6 +10,15 @@ Scan gated clock
 -  **Inputs**:  3 (GATE, CLK, SCE)
 -  **Outputs**: 1 (GCLK)
 
+sg13g2_slgcp_1 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_slgcp_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_slgcp_1 symbol
+
 sg13g2_slgcp_1 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_tiehi.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_tiehi.rst
@@ -10,6 +10,15 @@ Constant logic 0
 -  **Inputs**:  0 ()
 -  **Outputs**: 1 (L_HI)
 
+sg13g2_tiehi symbol
+-------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_tiehi.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_tiehi symbol
+
 sg13g2_tiehi schematic
 ----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_tielo.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_tielo.rst
@@ -10,6 +10,15 @@ Constant logic 1
 -  **Inputs**:  0 ()
 -  **Outputs**: 1 (L_LO)
 
+sg13g2_tielo symbol
+-------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_tielo.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_tielo symbol
+
 sg13g2_tielo schematic
 ----------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_xnor2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_xnor2_1.rst
@@ -10,6 +10,15 @@ sg13g2_xnor2_1
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (Y)
 
+sg13g2_xnor2_1 symbol
+---------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_xnor2_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_xnor2_1 symbol
+
 sg13g2_xnor2_1 schematic
 ------------------------
 

--- a/docs/libraries/sg13g2_stdcell/cells/sg13g2_xor2_1.rst
+++ b/docs/libraries/sg13g2_stdcell/cells/sg13g2_xor2_1.rst
@@ -10,6 +10,15 @@ sg13g2_xor2_1
 -  **Inputs**:  2 (A, B)
 -  **Outputs**: 1 (X)
 
+sg13g2_xor2_1 symbol
+--------------------
+
+.. figure:: ../../../_static/symbols/sg13g2_xor2_1.svg
+    :align: center
+    :width: 60%
+
+    sg13g2_xor2_1 symbol
+
 sg13g2_xor2_1 schematic
 -----------------------
 

--- a/scripts/generate_cell_docs.py
+++ b/scripts/generate_cell_docs.py
@@ -110,6 +110,15 @@ def generate_rst(cell, output_dir, image_relative_path):
         f.write(f"-  **Inputs**:  {len(cell['inputs'])} ({', '.join(cell['inputs'])})\n")
         f.write(f"-  **Outputs**: {len(cell['outputs'])} ({', '.join(cell['outputs'])})\n\n")
 
+        f.write(f"{cell['name']} symbol\n")
+        f.write("-" * (len(cell['name']) + 7) + "\n\n")
+
+        symbol_name = f"{cell['name']}.svg"
+        f.write(f".. figure:: ../../../_static/symbols/{symbol_name}\n")
+        f.write("    :align: center\n")
+        f.write("    :width: 60%\n\n")
+        f.write(f"    {cell['name']} symbol\n\n")
+
         f.write(f"{cell['name']} schematic\n")
         f.write("-" * (len(cell['name']) + 10) + "\n\n")
 

--- a/scripts/generate_symbols.py
+++ b/scripts/generate_symbols.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import shutil
+
+# Add symbolator and hdlparse to sys.path
+script_dir = os.path.dirname(os.path.abspath(__file__))
+repo_root = os.path.abspath(os.path.join(script_dir, ".."))
+sys.path.append(os.path.join(repo_root, "symbolator"))
+sys.path.append(os.path.join(repo_root, "hdlparse"))
+
+from symbolator import make_symbol, HdlSymbol, DrawStyle
+from nucanvas import NuCanvas
+from nucanvas.svg_backend import SvgSurface
+from nucanvas.shapes import PathShape, OvalShape
+from hdlparse import verilog_parser as vlog
+
+def generate_symbols():
+    verilog_path = os.path.join(repo_root, "ihp-sg13g2/libs.ref/sg13g2_stdcell/verilog/sg13g2_stdcell.v")
+    output_dir = os.path.join(repo_root, "docs/_static/symbols")
+
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    print(f"Parsing Verilog: {verilog_path}")
+    vlog_ex = vlog.VerilogExtractor()
+    components = vlog_ex.extract_objects(verilog_path)
+    print(f"Found {len(components)} components.")
+
+    style = DrawStyle()
+    style.line_color = (0, 0, 0)
+
+    nc = NuCanvas(None)
+    # Set markers (copied from symbolator.py)
+    nc.add_marker('arrow_fwd',
+                 PathShape(((0, -4), (2, -1, 2, 1, 0, 4), (8, 0), 'z'), fill=(0, 0, 0), weight=0),
+                 (3.2, 0), 'auto', None)
+
+    nc.add_marker('arrow_back',
+                  PathShape(((0, -4), (-2, -1, -2, 1, 0, 4), (-8, 0), 'z'), fill=(0, 0, 0), weight=0),
+                  (-3.2, 0), 'auto', None)
+
+    nc.add_marker('bubble',
+                  OvalShape(-3, -3, 3, 3, fill=(255, 255, 255), weight=1),
+                  (0, 0), 'auto', None)
+
+    nc.add_marker('clock',
+                  PathShape(((0, -7), (0, 7), (7, 0), 'z'), fill=(255, 255, 255), weight=1),
+                  (0, 0), 'auto', None)
+
+    for comp in components:
+        fname = os.path.join(output_dir, f"{comp.name}.svg")
+        print(f"Generating symbol for {comp.name} -> {fname}")
+
+        surf = SvgSurface(fname, style, padding=5, scale=1.0)
+        nc.set_surface(surf)
+        nc.clear_shapes()
+
+        sym = make_symbol(comp, vlog_ex, title=False, no_type=True)
+        sym.draw(0, 0, nc)
+        nc.render()
+
+if __name__ == "__main__":
+    generate_symbols()


### PR DESCRIPTION
Implemented high-level symbol generation for the IHP SG13G2 PDK standard cell library. This included fixing the vendored `Symbolator` and `hdlparse` tools for Python 3 compatibility and providing a fallback for Cairo/Pango dependencies. An automation script `scripts/generate_symbols.py` was added to generate symbols for all 84 standard cells, which are then integrated into the documentation via an updated `scripts/generate_cell_docs.py`. Generated documentation artifacts are now correctly ignored by Git.

Fixes #43

---
*PR created automatically by Jules for task [10954878119739687364](https://jules.google.com/task/10954878119739687364) started by @chatelao*