### PR TITLE
Include power and bias signals in standard cell symbols

### DIFF
--- a/docs/_static/symbols/sg13g2_a21o_1.svg
+++ b/docs/_static/symbols/sg13g2_a21o_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
+width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,23 +19,39 @@ width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A2</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
 </g>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_a21o_1.svg
+++ b/docs/_static/symbols/sg13g2_a21o_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,46 +26,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A1</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A2</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B1</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_a21o_1</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_a21o_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_a21o_1.svg
+++ b/docs/_static/symbols/sg13g2_a21o_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,40 +25,47 @@ width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
 </g>
-<g transform="translate(60.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_a21o_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_a21o_2.svg
+++ b/docs/_static/symbols/sg13g2_a21o_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,46 +26,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A1</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A2</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B1</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_a21o_2</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_a21o_2</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_a21o_2.svg
+++ b/docs/_static/symbols/sg13g2_a21o_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
+width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,23 +19,39 @@ width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A2</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
 </g>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_a21o_2.svg
+++ b/docs/_static/symbols/sg13g2_a21o_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,40 +25,47 @@ width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
 </g>
-<g transform="translate(60.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_a21o_2</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_a21oi_1.svg
+++ b/docs/_static/symbols/sg13g2_a21oi_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,46 +26,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A1</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A2</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B1</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_a21oi_1</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_a21oi_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_a21oi_1.svg
+++ b/docs/_static/symbols/sg13g2_a21oi_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
+width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,23 +19,39 @@ width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A2</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
 </g>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_a21oi_1.svg
+++ b/docs/_static/symbols/sg13g2_a21oi_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,40 +25,47 @@ width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
 </g>
-<g transform="translate(60.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_a21oi_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_a21oi_2.svg
+++ b/docs/_static/symbols/sg13g2_a21oi_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,46 +26,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A1</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A2</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B1</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_a21oi_2</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_a21oi_2</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_a21oi_2.svg
+++ b/docs/_static/symbols/sg13g2_a21oi_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,40 +25,47 @@ width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
 </g>
-<g transform="translate(60.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_a21oi_2</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_a21oi_2.svg
+++ b/docs/_static/symbols/sg13g2_a21oi_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
+width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,23 +19,39 @@ width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A2</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
 </g>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_a221oi_1.svg
+++ b/docs/_static/symbols/sg13g2_a221oi_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="161" viewBox="-25 -40 111.0 161.0" version="1.1">
+width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,48 +25,55 @@ width="111" height="161" viewBox="-25 -40 111.0 161.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="110.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="124.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
 </g>
-<g transform="translate(0,60)">
+<g transform="translate(0,74.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B2</text>
 </g>
-<g transform="translate(0,80)">
+<g transform="translate(0,94.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C1</text>
 </g>
-<g transform="translate(60.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,95.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,95.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="108.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,124.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_a221oi_1</text>
+<text class="fnt4" x="60.0" y="222.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_a221oi_1.svg
+++ b/docs/_static/symbols/sg13g2_a221oi_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="121" viewBox="-25 -20 111.0 121.0" version="1.1">
+width="111" height="161" viewBox="-25 -40 111.0 161.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,31 +19,47 @@ width="111" height="121" viewBox="-25 -20 111.0 121.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="110.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A2</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
 </g>
 <g transform="translate(0,60)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B2</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B2</text>
 </g>
 <g transform="translate(0,80)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C1</text>
 </g>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,95.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,95.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="108.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_a221oi_1.svg
+++ b/docs/_static/symbols/sg13g2_a221oi_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
+width="171" height="300" viewBox="-25 -44 171.0 300.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,54 +26,54 @@ width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="124.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="134.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A1</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A2</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B1</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B2</text>
 </g>
-<g transform="translate(0,94.4)">
+<g transform="translate(0,104.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">C1</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
 </g>
-<g transform="translate(0,124.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<g transform="translate(0,134.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_a221oi_1</text>
-<text class="fnt4" x="60.0" y="222.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="246.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_a221oi_1</text>
+<text class="fnt4" x="60.0" y="242.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_a22oi_1.svg
+++ b/docs/_static/symbols/sg13g2_a22oi_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="141" viewBox="-25 -40 111.0 141.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,44 +25,51 @@ width="111" height="141" viewBox="-25 -40 111.0 141.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
 </g>
-<g transform="translate(0,60)">
+<g transform="translate(0,74.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B2</text>
 </g>
-<g transform="translate(60.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,75.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,75.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,104.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_a22oi_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_a22oi_1.svg
+++ b/docs/_static/symbols/sg13g2_a22oi_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="101" viewBox="-25 -20 111.0 101.0" version="1.1">
+width="111" height="141" viewBox="-25 -40 111.0 141.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,27 +19,43 @@ width="111" height="101" viewBox="-25 -20 111.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A2</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
 </g>
 <g transform="translate(0,60)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B2</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B2</text>
 </g>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,75.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,75.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_a22oi_1.svg
+++ b/docs/_static/symbols/sg13g2_a22oi_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
+width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,50 +26,50 @@ width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A1</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A2</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B1</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B2</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
 </g>
-<g transform="translate(0,104.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<g transform="translate(0,114.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_a22oi_1</text>
-<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_a22oi_1</text>
+<text class="fnt4" x="60.0" y="222.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_and2_1.svg
+++ b/docs/_static/symbols/sg13g2_and2_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,36 +25,43 @@ width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_and2_1</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_and2_1.svg
+++ b/docs/_static/symbols/sg13g2_and2_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,42 +26,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_and2_1</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_and2_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_and2_1.svg
+++ b/docs/_static/symbols/sg13g2_and2_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,19 +19,35 @@ width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_and2_2.svg
+++ b/docs/_static/symbols/sg13g2_and2_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,42 +26,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_and2_2</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_and2_2</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_and2_2.svg
+++ b/docs/_static/symbols/sg13g2_and2_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,36 +25,43 @@ width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_and2_2</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_and2_2.svg
+++ b/docs/_static/symbols/sg13g2_and2_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,19 +19,35 @@ width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_and3_1.svg
+++ b/docs/_static/symbols/sg13g2_and3_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,40 +25,47 @@ width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_and3_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_and3_1.svg
+++ b/docs/_static/symbols/sg13g2_and3_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
+width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,23 +19,39 @@ width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_and3_1.svg
+++ b/docs/_static/symbols/sg13g2_and3_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,46 +26,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">C</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_and3_1</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_and3_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_and3_2.svg
+++ b/docs/_static/symbols/sg13g2_and3_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,40 +25,47 @@ width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_and3_2</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_and3_2.svg
+++ b/docs/_static/symbols/sg13g2_and3_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
+width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,23 +19,39 @@ width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_and3_2.svg
+++ b/docs/_static/symbols/sg13g2_and3_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,46 +26,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">C</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_and3_2</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_and3_2</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_and4_1.svg
+++ b/docs/_static/symbols/sg13g2_and4_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
+width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,27 +19,43 @@ width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
 <g transform="translate(0,60)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,75.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,75.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_and4_1.svg
+++ b/docs/_static/symbols/sg13g2_and4_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,44 +25,51 @@ width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
-<g transform="translate(0,60)">
+<g transform="translate(0,74.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,75.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,75.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,104.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_and4_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_and4_1.svg
+++ b/docs/_static/symbols/sg13g2_and4_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
+width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,50 +26,50 @@ width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">C</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
 </g>
-<g transform="translate(0,104.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<g transform="translate(0,114.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_and4_1</text>
-<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_and4_1</text>
+<text class="fnt4" x="60.0" y="222.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_and4_2.svg
+++ b/docs/_static/symbols/sg13g2_and4_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
+width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,27 +19,43 @@ width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
 <g transform="translate(0,60)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,75.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,75.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_and4_2.svg
+++ b/docs/_static/symbols/sg13g2_and4_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,44 +25,51 @@ width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
-<g transform="translate(0,60)">
+<g transform="translate(0,74.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,75.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,75.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,104.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_and4_2</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_and4_2.svg
+++ b/docs/_static/symbols/sg13g2_and4_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
+width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,50 +26,50 @@ width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">C</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
 </g>
-<g transform="translate(0,104.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<g transform="translate(0,114.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_and4_2</text>
-<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_and4_2</text>
+<text class="fnt4" x="60.0" y="222.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_antennanp.svg
+++ b/docs/_static/symbols/sg13g2_antennanp.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="71" height="81" viewBox="-25 -40 71.0 81.0" version="1.1">
+width="163" height="200" viewBox="-31 -44 163.6 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,28 +25,35 @@ width="71" height="81" viewBox="-25 -40 71.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-31" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="100.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="50.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_antennanp</text>
+<text class="fnt4" x="50.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_antennanp.svg
+++ b/docs/_static/symbols/sg13g2_antennanp.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="71" height="41" viewBox="-25 -20 71.0 41.0" version="1.1">
+width="71" height="81" viewBox="-25 -40 71.0 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,11 +19,27 @@ width="71" height="41" viewBox="-25 -20 71.0 41.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_antennanp.svg
+++ b/docs/_static/symbols/sg13g2_antennanp.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="163" height="200" viewBox="-31 -44 163.6 200.0" version="1.1">
+width="163" height="220" viewBox="-31 -44 163.6 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,34 +26,34 @@ width="163" height="200" viewBox="-31 -44 163.6 200.0" version="1.1">
 
 </defs>
 <rect x="-31" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="100.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="100.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="100.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="50.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_antennanp</text>
-<text class="fnt4" x="50.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="98.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="50.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_antennanp</text>
+<text class="fnt4" x="50.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_buf_1.svg
+++ b/docs/_static/symbols/sg13g2_buf_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,38 +26,38 @@ width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_buf_1</text>
-<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_buf_1</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_buf_1.svg
+++ b/docs/_static/symbols/sg13g2_buf_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,15 +19,31 @@ width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_buf_1.svg
+++ b/docs/_static/symbols/sg13g2_buf_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
+width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,32 +25,39 @@ width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_buf_1</text>
+<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_buf_16.svg
+++ b/docs/_static/symbols/sg13g2_buf_16.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,15 +19,31 @@ width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_buf_16.svg
+++ b/docs/_static/symbols/sg13g2_buf_16.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,38 +26,38 @@ width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_buf_16</text>
-<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_buf_16</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_buf_16.svg
+++ b/docs/_static/symbols/sg13g2_buf_16.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
+width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,32 +25,39 @@ width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_buf_16</text>
+<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_buf_2.svg
+++ b/docs/_static/symbols/sg13g2_buf_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,38 +26,38 @@ width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_buf_2</text>
-<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_buf_2</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_buf_2.svg
+++ b/docs/_static/symbols/sg13g2_buf_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
+width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,32 +25,39 @@ width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_buf_2</text>
+<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_buf_2.svg
+++ b/docs/_static/symbols/sg13g2_buf_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,15 +19,31 @@ width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_buf_4.svg
+++ b/docs/_static/symbols/sg13g2_buf_4.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
+width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,32 +25,39 @@ width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_buf_4</text>
+<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_buf_4.svg
+++ b/docs/_static/symbols/sg13g2_buf_4.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,38 +26,38 @@ width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_buf_4</text>
-<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_buf_4</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_buf_4.svg
+++ b/docs/_static/symbols/sg13g2_buf_4.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,15 +19,31 @@ width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_buf_8.svg
+++ b/docs/_static/symbols/sg13g2_buf_8.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,15 +19,31 @@ width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_buf_8.svg
+++ b/docs/_static/symbols/sg13g2_buf_8.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
+width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,32 +25,39 @@ width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_buf_8</text>
+<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_buf_8.svg
+++ b/docs/_static/symbols/sg13g2_buf_8.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,38 +26,38 @@ width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_buf_8</text>
-<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_buf_8</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_decap_4.svg
+++ b/docs/_static/symbols/sg13g2_decap_4.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="144" height="155" viewBox="-42 -44 144.4 155.60000000000002" version="1.1">
+width="144" height="165" viewBox="-42 -44 144.4 165.60000000000002" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,26 +26,26 @@ width="144" height="155" viewBox="-42 -44 144.4 155.60000000000002" version="1.1
 
 </defs>
 <rect x="-42" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="60.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="102.4" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_decap_4</text>
-<text class="fnt4" x="30.0" y="98.4" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="58.0" height="112.4" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_decap_4</text>
+<text class="fnt4" x="30.0" y="108.4" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_decap_4.svg
+++ b/docs/_static/symbols/sg13g2_decap_4.svg
@@ -3,10 +3,11 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
+width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
 <style type="text/css">
 <![CDATA[
-
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -18,4 +19,24 @@ width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
 <defs>
 
 </defs>
-<rect x="-5" y="-5" width="100%" height="100%" fill="white"/></svg>
+<rect x="-12" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="20" height="10.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(6.666666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(6.666666666666667,-5.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(13.333333333333334,-5.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="18.0" height="8.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_decap_4.svg
+++ b/docs/_static/symbols/sg13g2_decap_4.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
+width="144" height="155" viewBox="-42 -44 144.4 155.60000000000002" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,24 +25,27 @@ width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-12" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="20" height="10.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(6.666666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+<rect x="-42" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
 </g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
-<g transform="translate(6.666666666666667,-5.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
-<g transform="translate(13.333333333333334,-5.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="18.0" height="8.0" stroke="#000000" fill="none" stroke-width="3"/>
+<rect x="1.0" y="-14.0" width="58.0" height="102.4" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_decap_4</text>
+<text class="fnt4" x="30.0" y="98.4" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_decap_8.svg
+++ b/docs/_static/symbols/sg13g2_decap_8.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
+width="144" height="155" viewBox="-42 -44 144.4 155.60000000000002" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,24 +25,27 @@ width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-12" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="20" height="10.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(6.666666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+<rect x="-42" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
 </g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
-<g transform="translate(6.666666666666667,-5.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
-<g transform="translate(13.333333333333334,-5.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="18.0" height="8.0" stroke="#000000" fill="none" stroke-width="3"/>
+<rect x="1.0" y="-14.0" width="58.0" height="102.4" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_decap_8</text>
+<text class="fnt4" x="30.0" y="98.4" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_decap_8.svg
+++ b/docs/_static/symbols/sg13g2_decap_8.svg
@@ -3,10 +3,11 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
+width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
 <style type="text/css">
 <![CDATA[
-
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -18,4 +19,24 @@ width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
 <defs>
 
 </defs>
-<rect x="-5" y="-5" width="100%" height="100%" fill="white"/></svg>
+<rect x="-12" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="20" height="10.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(6.666666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(6.666666666666667,-5.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(13.333333333333334,-5.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="18.0" height="8.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_decap_8.svg
+++ b/docs/_static/symbols/sg13g2_decap_8.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="144" height="155" viewBox="-42 -44 144.4 155.60000000000002" version="1.1">
+width="144" height="165" viewBox="-42 -44 144.4 165.60000000000002" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,26 +26,26 @@ width="144" height="155" viewBox="-42 -44 144.4 155.60000000000002" version="1.1
 
 </defs>
 <rect x="-42" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="60.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="102.4" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_decap_8</text>
-<text class="fnt4" x="30.0" y="98.4" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="58.0" height="112.4" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_decap_8</text>
+<text class="fnt4" x="30.0" y="108.4" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dfrbp_1.svg
+++ b/docs/_static/symbols/sg13g2_dfrbp_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
+width="191" height="240" viewBox="-25 -44 191.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -17,53 +23,60 @@ width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="140.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
-<g transform="translate(100.0,0)">
+<g transform="translate(140.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
-<g transform="translate(100.0,20)">
+<g transform="translate(140.0,34.4)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
-</g>
-<g transform="translate(33.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(66.66666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(33.333333333333336,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(66.66666666666667,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="138.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dfrbp_1</text>
+<text class="fnt4" x="70.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dfrbp_1.svg
+++ b/docs/_static/symbols/sg13g2_dfrbp_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="191" height="240" viewBox="-25 -44 191.0 240.0" version="1.1">
+width="191" height="260" viewBox="-25 -44 191.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -23,60 +23,60 @@ width="191" height="240" viewBox="-25 -44 191.0 240.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="140.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="140.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">CLK</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">RESET_B</text>
 </g>
-<g transform="translate(140.0,14.399999999999999)">
+<g transform="translate(140.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q</text>
 </g>
-<g transform="translate(140.0,34.4)">
+<g transform="translate(140.0,44.4)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q_N</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="140.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="138.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dfrbp_1</text>
-<text class="fnt4" x="70.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="138.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_dfrbp_1</text>
+<text class="fnt4" x="70.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dfrbp_1.svg
+++ b/docs/_static/symbols/sg13g2_dfrbp_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,27 +26,43 @@ width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
 <g transform="translate(100.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
 <g transform="translate(100.0,20)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q_N</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
+</g>
+<g transform="translate(33.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(66.66666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(33.333333333333336,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(66.66666666666667,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_dfrbp_2.svg
+++ b/docs/_static/symbols/sg13g2_dfrbp_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="191" height="240" viewBox="-25 -44 191.0 240.0" version="1.1">
+width="191" height="260" viewBox="-25 -44 191.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -23,60 +23,60 @@ width="191" height="240" viewBox="-25 -44 191.0 240.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="140.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="140.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">CLK</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">RESET_B</text>
 </g>
-<g transform="translate(140.0,14.399999999999999)">
+<g transform="translate(140.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q</text>
 </g>
-<g transform="translate(140.0,34.4)">
+<g transform="translate(140.0,44.4)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q_N</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="140.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="138.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dfrbp_2</text>
-<text class="fnt4" x="70.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="138.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_dfrbp_2</text>
+<text class="fnt4" x="70.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dfrbp_2.svg
+++ b/docs/_static/symbols/sg13g2_dfrbp_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
+width="191" height="240" viewBox="-25 -44 191.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -17,53 +23,60 @@ width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="140.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
-<g transform="translate(100.0,0)">
+<g transform="translate(140.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
-<g transform="translate(100.0,20)">
+<g transform="translate(140.0,34.4)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
-</g>
-<g transform="translate(33.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(66.66666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(33.333333333333336,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(66.66666666666667,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="138.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dfrbp_2</text>
+<text class="fnt4" x="70.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dfrbp_2.svg
+++ b/docs/_static/symbols/sg13g2_dfrbp_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,27 +26,43 @@ width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
 <g transform="translate(100.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
 <g transform="translate(100.0,20)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q_N</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
+</g>
+<g transform="translate(33.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(66.66666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(33.333333333333336,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(66.66666666666667,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_dfrbpq_1.svg
+++ b/docs/_static/symbols/sg13g2_dfrbpq_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -23,56 +23,56 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">CLK</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">RESET_B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dfrbpq_1</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_dfrbpq_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dfrbpq_1.svg
+++ b/docs/_static/symbols/sg13g2_dfrbpq_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -17,49 +23,56 @@ width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
-<g transform="translate(100.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
-</g>
-<g transform="translate(33.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(66.66666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(33.333333333333336,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(66.66666666666667,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dfrbpq_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dfrbpq_1.svg
+++ b/docs/_static/symbols/sg13g2_dfrbpq_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,23 +26,39 @@ width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
 <g transform="translate(100.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+</g>
+<g transform="translate(33.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(66.66666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(33.333333333333336,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(66.66666666666667,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_dfrbpq_2.svg
+++ b/docs/_static/symbols/sg13g2_dfrbpq_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -23,56 +23,56 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">CLK</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">RESET_B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dfrbpq_2</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_dfrbpq_2</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dfrbpq_2.svg
+++ b/docs/_static/symbols/sg13g2_dfrbpq_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,23 +26,39 @@ width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
 <g transform="translate(100.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+</g>
+<g transform="translate(33.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(66.66666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(33.333333333333336,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(66.66666666666667,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_dfrbpq_2.svg
+++ b/docs/_static/symbols/sg13g2_dfrbpq_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -17,49 +23,56 @@ width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
-<g transform="translate(100.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
-</g>
-<g transform="translate(33.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(66.66666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(33.333333333333336,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(66.66666666666667,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dfrbpq_2</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dlhq_1.svg
+++ b/docs/_static/symbols/sg13g2_dlhq_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
+width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,19 +19,35 @@ width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">GATE</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
 </g>
 <g transform="translate(80.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(53.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(53.333333333333336,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_dlhq_1.svg
+++ b/docs/_static/symbols/sg13g2_dlhq_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,42 +26,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">GATE</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dlhq_1</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_dlhq_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dlhq_1.svg
+++ b/docs/_static/symbols/sg13g2_dlhq_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,36 +25,43 @@ width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
 </g>
-<g transform="translate(80.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(53.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(53.333333333333336,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dlhq_1</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dlhr_1.svg
+++ b/docs/_static/symbols/sg13g2_dlhr_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,27 +22,43 @@ width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">GATE</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
 <g transform="translate(100.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
 <g transform="translate(100.0,20)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q_N</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
+</g>
+<g transform="translate(33.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(66.66666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(33.333333333333336,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(66.66666666666667,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_dlhr_1.svg
+++ b/docs/_static/symbols/sg13g2_dlhr_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
+width="191" height="240" viewBox="-25 -44 191.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,44 +28,51 @@ width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="140.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
-<g transform="translate(100.0,0)">
+<g transform="translate(140.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
-<g transform="translate(100.0,20)">
+<g transform="translate(140.0,34.4)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
-</g>
-<g transform="translate(33.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(66.66666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(33.333333333333336,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(66.66666666666667,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="138.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dlhr_1</text>
+<text class="fnt4" x="70.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dlhr_1.svg
+++ b/docs/_static/symbols/sg13g2_dlhr_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="191" height="240" viewBox="-25 -44 191.0 240.0" version="1.1">
+width="191" height="260" viewBox="-25 -44 191.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,50 +29,50 @@ width="191" height="240" viewBox="-25 -44 191.0 240.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="140.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="140.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">GATE</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">RESET_B</text>
 </g>
-<g transform="translate(140.0,14.399999999999999)">
+<g transform="translate(140.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q</text>
 </g>
-<g transform="translate(140.0,34.4)">
+<g transform="translate(140.0,44.4)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q_N</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="140.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="138.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dlhr_1</text>
-<text class="fnt4" x="70.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="138.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_dlhr_1</text>
+<text class="fnt4" x="70.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dlhrq_1.svg
+++ b/docs/_static/symbols/sg13g2_dlhrq_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,23 +22,39 @@ width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">GATE</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
 <g transform="translate(100.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+</g>
+<g transform="translate(33.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(66.66666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(33.333333333333336,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(66.66666666666667,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_dlhrq_1.svg
+++ b/docs/_static/symbols/sg13g2_dlhrq_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,46 +29,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">GATE</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">RESET_B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dlhrq_1</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_dlhrq_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dlhrq_1.svg
+++ b/docs/_static/symbols/sg13g2_dlhrq_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,40 +28,47 @@ width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
-<g transform="translate(100.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
-</g>
-<g transform="translate(33.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(66.66666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(33.333333333333336,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(66.66666666666667,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dlhrq_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dllr_1.svg
+++ b/docs/_static/symbols/sg13g2_dllr_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
+width="191" height="240" viewBox="-25 -44 191.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,44 +28,51 @@ width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="140.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE_N</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE_N</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
-<g transform="translate(100.0,0)">
+<g transform="translate(140.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
-<g transform="translate(100.0,20)">
+<g transform="translate(140.0,34.4)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
-</g>
-<g transform="translate(33.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(66.66666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(33.333333333333336,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(66.66666666666667,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="138.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dllr_1</text>
+<text class="fnt4" x="70.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dllr_1.svg
+++ b/docs/_static/symbols/sg13g2_dllr_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,27 +22,43 @@ width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">GATE_N</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE_N</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
 <g transform="translate(100.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
 <g transform="translate(100.0,20)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q_N</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
+</g>
+<g transform="translate(33.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(66.66666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(33.333333333333336,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(66.66666666666667,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_dllr_1.svg
+++ b/docs/_static/symbols/sg13g2_dllr_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="191" height="240" viewBox="-25 -44 191.0 240.0" version="1.1">
+width="191" height="260" viewBox="-25 -44 191.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,50 +29,50 @@ width="191" height="240" viewBox="-25 -44 191.0 240.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="140.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="140.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE_N</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">GATE_N</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">RESET_B</text>
 </g>
-<g transform="translate(140.0,14.399999999999999)">
+<g transform="translate(140.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q</text>
 </g>
-<g transform="translate(140.0,34.4)">
+<g transform="translate(140.0,44.4)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q_N</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="140.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="138.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dllr_1</text>
-<text class="fnt4" x="70.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="138.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_dllr_1</text>
+<text class="fnt4" x="70.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dllrq_1.svg
+++ b/docs/_static/symbols/sg13g2_dllrq_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,40 +28,47 @@ width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE_N</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE_N</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
-<g transform="translate(100.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
-</g>
-<g transform="translate(33.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(66.66666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(33.333333333333336,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(66.66666666666667,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dllrq_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dllrq_1.svg
+++ b/docs/_static/symbols/sg13g2_dllrq_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,23 +22,39 @@ width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">GATE_N</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE_N</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
 <g transform="translate(100.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+</g>
+<g transform="translate(33.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(66.66666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(33.333333333333336,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(66.66666666666667,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_dllrq_1.svg
+++ b/docs/_static/symbols/sg13g2_dllrq_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,46 +29,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE_N</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">GATE_N</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">RESET_B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dllrq_1</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_dllrq_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dlygate4sd1_1.svg
+++ b/docs/_static/symbols/sg13g2_dlygate4sd1_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="202" height="200" viewBox="-41 -44 202.0 200.0" version="1.1">
+width="202" height="220" viewBox="-41 -44 202.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,38 +26,38 @@ width="202" height="200" viewBox="-41 -44 202.0 200.0" version="1.1">
 
 </defs>
 <rect x="-41" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dlygate4sd1_1</text>
-<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_dlygate4sd1_1</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dlygate4sd1_1.svg
+++ b/docs/_static/symbols/sg13g2_dlygate4sd1_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,15 +19,31 @@ width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_dlygate4sd1_1.svg
+++ b/docs/_static/symbols/sg13g2_dlygate4sd1_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
+width="202" height="200" viewBox="-41 -44 202.0 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,32 +25,39 @@ width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-41" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dlygate4sd1_1</text>
+<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dlygate4sd2_1.svg
+++ b/docs/_static/symbols/sg13g2_dlygate4sd2_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="202" height="200" viewBox="-41 -44 202.0 200.0" version="1.1">
+width="202" height="220" viewBox="-41 -44 202.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,38 +26,38 @@ width="202" height="200" viewBox="-41 -44 202.0 200.0" version="1.1">
 
 </defs>
 <rect x="-41" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dlygate4sd2_1</text>
-<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_dlygate4sd2_1</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dlygate4sd2_1.svg
+++ b/docs/_static/symbols/sg13g2_dlygate4sd2_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
+width="202" height="200" viewBox="-41 -44 202.0 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,32 +25,39 @@ width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-41" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dlygate4sd2_1</text>
+<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dlygate4sd2_1.svg
+++ b/docs/_static/symbols/sg13g2_dlygate4sd2_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,15 +19,31 @@ width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_dlygate4sd3_1.svg
+++ b/docs/_static/symbols/sg13g2_dlygate4sd3_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="202" height="200" viewBox="-41 -44 202.0 200.0" version="1.1">
+width="202" height="220" viewBox="-41 -44 202.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,38 +26,38 @@ width="202" height="200" viewBox="-41 -44 202.0 200.0" version="1.1">
 
 </defs>
 <rect x="-41" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dlygate4sd3_1</text>
-<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_dlygate4sd3_1</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dlygate4sd3_1.svg
+++ b/docs/_static/symbols/sg13g2_dlygate4sd3_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
+width="202" height="200" viewBox="-41 -44 202.0 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,32 +25,39 @@ width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-41" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_dlygate4sd3_1</text>
+<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_dlygate4sd3_1.svg
+++ b/docs/_static/symbols/sg13g2_dlygate4sd3_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,15 +19,31 @@ width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_ebufn_2.svg
+++ b/docs/_static/symbols/sg13g2_ebufn_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,42 +29,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">TE_B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Z</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_ebufn_2</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_ebufn_2</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_ebufn_2.svg
+++ b/docs/_static/symbols/sg13g2_ebufn_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,36 +28,43 @@ width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
 </g>
-<g transform="translate(80.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(53.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(53.333333333333336,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_ebufn_2</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_ebufn_2.svg
+++ b/docs/_static/symbols/sg13g2_ebufn_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
+width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,19 +22,35 @@ width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">TE_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
 </g>
 <g transform="translate(80.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Z</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(53.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(53.333333333333336,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_ebufn_4.svg
+++ b/docs/_static/symbols/sg13g2_ebufn_4.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,42 +29,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">TE_B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Z</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_ebufn_4</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_ebufn_4</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_ebufn_4.svg
+++ b/docs/_static/symbols/sg13g2_ebufn_4.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,36 +28,43 @@ width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
 </g>
-<g transform="translate(80.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(53.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(53.333333333333336,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_ebufn_4</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_ebufn_4.svg
+++ b/docs/_static/symbols/sg13g2_ebufn_4.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
+width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,19 +22,35 @@ width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">TE_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
 </g>
 <g transform="translate(80.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Z</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(53.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(53.333333333333336,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_ebufn_8.svg
+++ b/docs/_static/symbols/sg13g2_ebufn_8.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,42 +29,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">TE_B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Z</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_ebufn_8</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_ebufn_8</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_ebufn_8.svg
+++ b/docs/_static/symbols/sg13g2_ebufn_8.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,36 +28,43 @@ width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
 </g>
-<g transform="translate(80.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(53.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(53.333333333333336,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_ebufn_8</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_ebufn_8.svg
+++ b/docs/_static/symbols/sg13g2_ebufn_8.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
+width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,19 +22,35 @@ width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">TE_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
 </g>
 <g transform="translate(80.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Z</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(53.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(53.333333333333336,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_einvn_2.svg
+++ b/docs/_static/symbols/sg13g2_einvn_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,36 +28,43 @@ width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
 </g>
-<g transform="translate(80.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(53.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(53.333333333333336,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_einvn_2</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_einvn_2.svg
+++ b/docs/_static/symbols/sg13g2_einvn_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
+width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,19 +22,35 @@ width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">TE_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
 </g>
 <g transform="translate(80.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Z</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(53.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(53.333333333333336,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_einvn_2.svg
+++ b/docs/_static/symbols/sg13g2_einvn_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,42 +29,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">TE_B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Z</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_einvn_2</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_einvn_2</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_einvn_4.svg
+++ b/docs/_static/symbols/sg13g2_einvn_4.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,36 +28,43 @@ width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
 </g>
-<g transform="translate(80.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(53.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(53.333333333333336,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_einvn_4</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_einvn_4.svg
+++ b/docs/_static/symbols/sg13g2_einvn_4.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,42 +29,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">TE_B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Z</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_einvn_4</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_einvn_4</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_einvn_4.svg
+++ b/docs/_static/symbols/sg13g2_einvn_4.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
+width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,19 +22,35 @@ width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">TE_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
 </g>
 <g transform="translate(80.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Z</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(53.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(53.333333333333336,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_einvn_8.svg
+++ b/docs/_static/symbols/sg13g2_einvn_8.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,42 +29,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">TE_B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Z</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_einvn_8</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_einvn_8</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_einvn_8.svg
+++ b/docs/_static/symbols/sg13g2_einvn_8.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,36 +28,43 @@ width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
 </g>
-<g transform="translate(80.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(53.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(53.333333333333336,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_einvn_8</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_einvn_8.svg
+++ b/docs/_static/symbols/sg13g2_einvn_8.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
+width="131" height="101" viewBox="-25 -40 131.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,19 +22,35 @@ width="131" height="61" viewBox="-25 -20 131.0 61.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="80.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">TE_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">TE_B</text>
 </g>
 <g transform="translate(80.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Z</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Z</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(53.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(53.333333333333336,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="78.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_fill_1.svg
+++ b/docs/_static/symbols/sg13g2_fill_1.svg
@@ -3,10 +3,11 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
+width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
 <style type="text/css">
 <![CDATA[
-
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -18,4 +19,24 @@ width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
 <defs>
 
 </defs>
-<rect x="-5" y="-5" width="100%" height="100%" fill="white"/></svg>
+<rect x="-12" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="20" height="10.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(6.666666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(6.666666666666667,-5.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(13.333333333333334,-5.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="18.0" height="8.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_fill_1.svg
+++ b/docs/_static/symbols/sg13g2_fill_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="134" height="155" viewBox="-37 -44 134.8 155.60000000000002" version="1.1">
+width="134" height="165" viewBox="-37 -44 134.8 165.60000000000002" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,26 +26,26 @@ width="134" height="155" viewBox="-37 -44 134.8 155.60000000000002" version="1.1
 
 </defs>
 <rect x="-37" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="60.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="102.4" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_fill_1</text>
-<text class="fnt4" x="30.0" y="98.4" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="58.0" height="112.4" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_fill_1</text>
+<text class="fnt4" x="30.0" y="108.4" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_fill_1.svg
+++ b/docs/_static/symbols/sg13g2_fill_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
+width="134" height="155" viewBox="-37 -44 134.8 155.60000000000002" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,24 +25,27 @@ width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-12" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="20" height="10.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(6.666666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+<rect x="-37" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
 </g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
-<g transform="translate(6.666666666666667,-5.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
-<g transform="translate(13.333333333333334,-5.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="18.0" height="8.0" stroke="#000000" fill="none" stroke-width="3"/>
+<rect x="1.0" y="-14.0" width="58.0" height="102.4" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_fill_1</text>
+<text class="fnt4" x="30.0" y="98.4" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_fill_2.svg
+++ b/docs/_static/symbols/sg13g2_fill_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="134" height="155" viewBox="-37 -44 134.8 155.60000000000002" version="1.1">
+width="134" height="165" viewBox="-37 -44 134.8 165.60000000000002" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,26 +26,26 @@ width="134" height="155" viewBox="-37 -44 134.8 155.60000000000002" version="1.1
 
 </defs>
 <rect x="-37" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="60.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="102.4" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_fill_2</text>
-<text class="fnt4" x="30.0" y="98.4" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="58.0" height="112.4" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_fill_2</text>
+<text class="fnt4" x="30.0" y="108.4" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_fill_2.svg
+++ b/docs/_static/symbols/sg13g2_fill_2.svg
@@ -3,10 +3,11 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
+width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
 <style type="text/css">
 <![CDATA[
-
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -18,4 +19,24 @@ width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
 <defs>
 
 </defs>
-<rect x="-5" y="-5" width="100%" height="100%" fill="white"/></svg>
+<rect x="-12" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="20" height="10.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(6.666666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(6.666666666666667,-5.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(13.333333333333334,-5.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="18.0" height="8.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_fill_2.svg
+++ b/docs/_static/symbols/sg13g2_fill_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
+width="134" height="155" viewBox="-37 -44 134.8 155.60000000000002" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,24 +25,27 @@ width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-12" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="20" height="10.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(6.666666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+<rect x="-37" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
 </g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
-<g transform="translate(6.666666666666667,-5.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
-<g transform="translate(13.333333333333334,-5.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="18.0" height="8.0" stroke="#000000" fill="none" stroke-width="3"/>
+<rect x="1.0" y="-14.0" width="58.0" height="102.4" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_fill_2</text>
+<text class="fnt4" x="30.0" y="98.4" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_fill_4.svg
+++ b/docs/_static/symbols/sg13g2_fill_4.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
+width="134" height="155" viewBox="-37 -44 134.8 155.60000000000002" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,24 +25,27 @@ width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-12" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="20" height="10.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(6.666666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+<rect x="-37" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
 </g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
-<g transform="translate(6.666666666666667,-5.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
-<g transform="translate(13.333333333333334,-5.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="18.0" height="8.0" stroke="#000000" fill="none" stroke-width="3"/>
+<rect x="1.0" y="-14.0" width="58.0" height="102.4" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_fill_4</text>
+<text class="fnt4" x="30.0" y="98.4" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_fill_4.svg
+++ b/docs/_static/symbols/sg13g2_fill_4.svg
@@ -3,10 +3,11 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
+width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
 <style type="text/css">
 <![CDATA[
-
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -18,4 +19,24 @@ width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
 <defs>
 
 </defs>
-<rect x="-5" y="-5" width="100%" height="100%" fill="white"/></svg>
+<rect x="-12" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="20" height="10.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(6.666666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(6.666666666666667,-5.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(13.333333333333334,-5.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="18.0" height="8.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_fill_4.svg
+++ b/docs/_static/symbols/sg13g2_fill_4.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="134" height="155" viewBox="-37 -44 134.8 155.60000000000002" version="1.1">
+width="134" height="165" viewBox="-37 -44 134.8 165.60000000000002" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,26 +26,26 @@ width="134" height="155" viewBox="-37 -44 134.8 155.60000000000002" version="1.1
 
 </defs>
 <rect x="-37" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="60.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="102.4" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_fill_4</text>
-<text class="fnt4" x="30.0" y="98.4" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="58.0" height="112.4" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_fill_4</text>
+<text class="fnt4" x="30.0" y="108.4" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_fill_8.svg
+++ b/docs/_static/symbols/sg13g2_fill_8.svg
@@ -3,10 +3,11 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
+width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
 <style type="text/css">
 <![CDATA[
-
+.fnt1 {fill:#000000;
+    font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -18,4 +19,24 @@ width="10" height="10" viewBox="-5 -5 10 10" version="1.1">
 <defs>
 
 </defs>
-<rect x="-5" y="-5" width="100%" height="100%" fill="white"/></svg>
+<rect x="-12" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="20" height="10.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<g transform="translate(6.666666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(6.666666666666667,-5.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(13.333333333333334,-5.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="18.0" height="8.0" stroke="#000000" fill="none" stroke-width="3"/>
+</svg>

--- a/docs/_static/symbols/sg13g2_fill_8.svg
+++ b/docs/_static/symbols/sg13g2_fill_8.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
+width="134" height="155" viewBox="-37 -44 134.8 155.60000000000002" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,24 +25,27 @@ width="41" height="61" viewBox="-12 -40 41.86666666666666 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-12" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="20" height="10.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(6.666666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+<rect x="-37" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="60.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
 </g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
-<g transform="translate(6.666666666666667,-5.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
-<g transform="translate(13.333333333333334,-5.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="18.0" height="8.0" stroke="#000000" fill="none" stroke-width="3"/>
+<rect x="1.0" y="-14.0" width="58.0" height="102.4" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_fill_8</text>
+<text class="fnt4" x="30.0" y="98.4" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_fill_8.svg
+++ b/docs/_static/symbols/sg13g2_fill_8.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="134" height="155" viewBox="-37 -44 134.8 155.60000000000002" version="1.1">
+width="134" height="165" viewBox="-37 -44 134.8 165.60000000000002" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,26 +26,26 @@ width="134" height="155" viewBox="-37 -44 134.8 155.60000000000002" version="1.1
 
 </defs>
 <rect x="-37" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="60.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="30.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="102.4" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_fill_8</text>
-<text class="fnt4" x="30.0" y="98.4" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="58.0" height="112.4" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="30.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_fill_8</text>
+<text class="fnt4" x="30.0" y="108.4" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_inv_1.svg
+++ b/docs/_static/symbols/sg13g2_inv_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
+width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,32 +25,39 @@ width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_inv_1</text>
+<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_inv_1.svg
+++ b/docs/_static/symbols/sg13g2_inv_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,15 +19,31 @@ width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_inv_1.svg
+++ b/docs/_static/symbols/sg13g2_inv_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,38 +26,38 @@ width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_inv_1</text>
-<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_inv_1</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_inv_16.svg
+++ b/docs/_static/symbols/sg13g2_inv_16.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
+width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,32 +25,39 @@ width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_inv_16</text>
+<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_inv_16.svg
+++ b/docs/_static/symbols/sg13g2_inv_16.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,15 +19,31 @@ width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_inv_16.svg
+++ b/docs/_static/symbols/sg13g2_inv_16.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,38 +26,38 @@ width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_inv_16</text>
-<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_inv_16</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_inv_2.svg
+++ b/docs/_static/symbols/sg13g2_inv_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,15 +19,31 @@ width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_inv_2.svg
+++ b/docs/_static/symbols/sg13g2_inv_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
+width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,32 +25,39 @@ width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_inv_2</text>
+<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_inv_2.svg
+++ b/docs/_static/symbols/sg13g2_inv_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,38 +26,38 @@ width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_inv_2</text>
-<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_inv_2</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_inv_4.svg
+++ b/docs/_static/symbols/sg13g2_inv_4.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
+width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,32 +25,39 @@ width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_inv_4</text>
+<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_inv_4.svg
+++ b/docs/_static/symbols/sg13g2_inv_4.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,15 +19,31 @@ width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_inv_4.svg
+++ b/docs/_static/symbols/sg13g2_inv_4.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,38 +26,38 @@ width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_inv_4</text>
-<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_inv_4</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_inv_8.svg
+++ b/docs/_static/symbols/sg13g2_inv_8.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
+width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,15 +19,31 @@ width="91" height="41" viewBox="-25 -20 91.0 41.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_inv_8.svg
+++ b/docs/_static/symbols/sg13g2_inv_8.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,38 +26,38 @@ width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_inv_8</text>
-<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_inv_8</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_inv_8.svg
+++ b/docs/_static/symbols/sg13g2_inv_8.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
+width="171" height="200" viewBox="-25 -44 171.0 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,32 +25,39 @@ width="91" height="81" viewBox="-25 -40 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_inv_8</text>
+<text class="fnt4" x="60.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_lgcp_1.svg
+++ b/docs/_static/symbols/sg13g2_lgcp_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="101" viewBox="-25 -40 151.0 101.0" version="1.1">
+width="191" height="220" viewBox="-25 -44 191.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,36 +28,43 @@ width="151" height="101" viewBox="-25 -40 151.0 101.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="140.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
 </g>
-<g transform="translate(100.0,0)">
+<g transform="translate(140.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">GCLK</text>
-</g>
-<g transform="translate(33.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(66.66666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(33.333333333333336,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(66.66666666666667,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">GCLK</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="138.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_lgcp_1</text>
+<text class="fnt4" x="70.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_lgcp_1.svg
+++ b/docs/_static/symbols/sg13g2_lgcp_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="191" height="220" viewBox="-25 -44 191.0 220.0" version="1.1">
+width="191" height="240" viewBox="-25 -44 191.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,42 +29,42 @@ width="191" height="220" viewBox="-25 -44 191.0 220.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="140.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="140.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">CLK</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">GATE</text>
 </g>
-<g transform="translate(140.0,14.399999999999999)">
+<g transform="translate(140.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">GCLK</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">GCLK</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="140.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="138.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_lgcp_1</text>
-<text class="fnt4" x="70.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="138.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_lgcp_1</text>
+<text class="fnt4" x="70.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_lgcp_1.svg
+++ b/docs/_static/symbols/sg13g2_lgcp_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="61" viewBox="-25 -20 151.0 61.0" version="1.1">
+width="151" height="101" viewBox="-25 -40 151.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,19 +22,35 @@ width="151" height="61" viewBox="-25 -20 151.0 61.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="100.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">GATE</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
 </g>
 <g transform="translate(100.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">GCLK</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">GCLK</text>
+</g>
+<g transform="translate(33.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(66.66666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(33.333333333333336,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(66.66666666666667,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="98.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_mux2_1.svg
+++ b/docs/_static/symbols/sg13g2_mux2_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,46 +26,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A0</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A0</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A1</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">S</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">S</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_mux2_1</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_mux2_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_mux2_1.svg
+++ b/docs/_static/symbols/sg13g2_mux2_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,40 +25,47 @@ width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A0</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A0</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">S</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">S</text>
 </g>
-<g transform="translate(60.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_mux2_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_mux2_1.svg
+++ b/docs/_static/symbols/sg13g2_mux2_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
+width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,23 +19,39 @@ width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A0</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A0</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">S</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">S</text>
 </g>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_mux2_2.svg
+++ b/docs/_static/symbols/sg13g2_mux2_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,46 +26,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A0</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A0</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A1</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">S</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">S</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_mux2_2</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_mux2_2</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_mux2_2.svg
+++ b/docs/_static/symbols/sg13g2_mux2_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,40 +25,47 @@ width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A0</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A0</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">S</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">S</text>
 </g>
-<g transform="translate(60.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_mux2_2</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_mux2_2.svg
+++ b/docs/_static/symbols/sg13g2_mux2_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
+width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,23 +19,39 @@ width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A0</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A0</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">S</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">S</text>
 </g>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_mux4_1.svg
+++ b/docs/_static/symbols/sg13g2_mux4_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="300" viewBox="-25 -44 171.0 300.0" version="1.1">
+width="171" height="320" viewBox="-25 -44 171.0 320.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,58 +26,58 @@ width="171" height="300" viewBox="-25 -44 171.0 300.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="144.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="154.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A0</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A0</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A1</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A2</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A3</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A3</text>
 </g>
-<g transform="translate(0,94.4)">
+<g transform="translate(0,104.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">S0</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">S0</text>
 </g>
-<g transform="translate(0,114.4)">
+<g transform="translate(0,124.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">S1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">S1</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
 </g>
-<g transform="translate(0,144.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<g transform="translate(0,154.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="246.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_mux4_1</text>
-<text class="fnt4" x="60.0" y="242.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="266.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_mux4_1</text>
+<text class="fnt4" x="60.0" y="262.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_mux4_1.svg
+++ b/docs/_static/symbols/sg13g2_mux4_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="141" viewBox="-25 -20 111.0 141.0" version="1.1">
+width="111" height="181" viewBox="-25 -40 111.0 181.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,35 +19,51 @@ width="111" height="141" viewBox="-25 -20 111.0 141.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="130.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A0</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A0</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A2</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
 </g>
 <g transform="translate(0,60)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A3</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A3</text>
 </g>
 <g transform="translate(0,80)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">S0</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">S0</text>
 </g>
 <g transform="translate(0,100)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">S1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">S1</text>
 </g>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,115.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,115.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="128.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_mux4_1.svg
+++ b/docs/_static/symbols/sg13g2_mux4_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="181" viewBox="-25 -40 111.0 181.0" version="1.1">
+width="171" height="300" viewBox="-25 -44 171.0 300.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,52 +25,59 @@ width="111" height="181" viewBox="-25 -40 111.0 181.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="130.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="144.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A0</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A0</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
 </g>
-<g transform="translate(0,60)">
+<g transform="translate(0,74.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A3</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A3</text>
 </g>
-<g transform="translate(0,80)">
+<g transform="translate(0,94.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">S0</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">S0</text>
 </g>
-<g transform="translate(0,100)">
+<g transform="translate(0,114.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">S1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">S1</text>
 </g>
-<g transform="translate(60.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,115.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,115.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="128.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,144.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="246.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_mux4_1</text>
+<text class="fnt4" x="60.0" y="242.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nand2_1.svg
+++ b/docs/_static/symbols/sg13g2_nand2_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,19 +19,35 @@ width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_nand2_1.svg
+++ b/docs/_static/symbols/sg13g2_nand2_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,42 +26,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nand2_1</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_nand2_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nand2_1.svg
+++ b/docs/_static/symbols/sg13g2_nand2_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,36 +25,43 @@ width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nand2_1</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nand2_2.svg
+++ b/docs/_static/symbols/sg13g2_nand2_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,19 +19,35 @@ width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_nand2_2.svg
+++ b/docs/_static/symbols/sg13g2_nand2_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,36 +25,43 @@ width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nand2_2</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nand2_2.svg
+++ b/docs/_static/symbols/sg13g2_nand2_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,42 +26,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nand2_2</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_nand2_2</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nand2b_1.svg
+++ b/docs/_static/symbols/sg13g2_nand2b_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="101" viewBox="-25 -40 111.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,36 +28,43 @@ width="111" height="101" viewBox="-25 -40 111.0 101.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A_N</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A_N</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(60.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nand2b_1</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nand2b_1.svg
+++ b/docs/_static/symbols/sg13g2_nand2b_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="61" viewBox="-25 -20 111.0 61.0" version="1.1">
+width="111" height="101" viewBox="-25 -40 111.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,19 +22,35 @@ width="111" height="61" viewBox="-25 -20 111.0 61.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A_N</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A_N</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_nand2b_1.svg
+++ b/docs/_static/symbols/sg13g2_nand2b_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,42 +29,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A_N</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A_N</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nand2b_1</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_nand2b_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nand2b_2.svg
+++ b/docs/_static/symbols/sg13g2_nand2b_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="61" viewBox="-25 -20 111.0 61.0" version="1.1">
+width="111" height="101" viewBox="-25 -40 111.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,19 +22,35 @@ width="111" height="61" viewBox="-25 -20 111.0 61.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A_N</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A_N</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_nand2b_2.svg
+++ b/docs/_static/symbols/sg13g2_nand2b_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,42 +29,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A_N</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A_N</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nand2b_2</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_nand2b_2</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nand2b_2.svg
+++ b/docs/_static/symbols/sg13g2_nand2b_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="101" viewBox="-25 -40 111.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,36 +28,43 @@ width="111" height="101" viewBox="-25 -40 111.0 101.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A_N</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A_N</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(60.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nand2b_2</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nand3_1.svg
+++ b/docs/_static/symbols/sg13g2_nand3_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,40 +25,47 @@ width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nand3_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nand3_1.svg
+++ b/docs/_static/symbols/sg13g2_nand3_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,46 +26,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">C</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nand3_1</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_nand3_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nand3_1.svg
+++ b/docs/_static/symbols/sg13g2_nand3_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
+width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,23 +19,39 @@ width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_nand3b_1.svg
+++ b/docs/_static/symbols/sg13g2_nand3b_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
+width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,23 +22,39 @@ width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A_N</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A_N</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_nand3b_1.svg
+++ b/docs/_static/symbols/sg13g2_nand3b_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,40 +28,47 @@ width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A_N</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A_N</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
-<g transform="translate(60.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nand3b_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nand3b_1.svg
+++ b/docs/_static/symbols/sg13g2_nand3b_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,46 +29,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A_N</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A_N</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">C</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nand3b_1</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_nand3b_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nand4_1.svg
+++ b/docs/_static/symbols/sg13g2_nand4_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,44 +25,51 @@ width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
-<g transform="translate(0,60)">
+<g transform="translate(0,74.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,75.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,75.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,104.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nand4_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nand4_1.svg
+++ b/docs/_static/symbols/sg13g2_nand4_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
+width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,27 +19,43 @@ width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
 <g transform="translate(0,60)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,75.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,75.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_nand4_1.svg
+++ b/docs/_static/symbols/sg13g2_nand4_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
+width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,50 +26,50 @@ width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">C</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
 </g>
-<g transform="translate(0,104.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<g transform="translate(0,114.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nand4_1</text>
-<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_nand4_1</text>
+<text class="fnt4" x="60.0" y="222.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nor2_1.svg
+++ b/docs/_static/symbols/sg13g2_nor2_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,19 +19,35 @@ width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_nor2_1.svg
+++ b/docs/_static/symbols/sg13g2_nor2_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,36 +25,43 @@ width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nor2_1</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nor2_1.svg
+++ b/docs/_static/symbols/sg13g2_nor2_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,42 +26,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nor2_1</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_nor2_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nor2_2.svg
+++ b/docs/_static/symbols/sg13g2_nor2_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,19 +19,35 @@ width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_nor2_2.svg
+++ b/docs/_static/symbols/sg13g2_nor2_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,42 +26,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nor2_2</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_nor2_2</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nor2_2.svg
+++ b/docs/_static/symbols/sg13g2_nor2_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,36 +25,43 @@ width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nor2_2</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nor2b_1.svg
+++ b/docs/_static/symbols/sg13g2_nor2b_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,42 +29,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B_N</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B_N</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nor2b_1</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_nor2b_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nor2b_1.svg
+++ b/docs/_static/symbols/sg13g2_nor2b_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="101" viewBox="-25 -40 111.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,36 +28,43 @@ width="111" height="101" viewBox="-25 -40 111.0 101.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B_N</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B_N</text>
 </g>
-<g transform="translate(60.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nor2b_1</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nor2b_1.svg
+++ b/docs/_static/symbols/sg13g2_nor2b_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="61" viewBox="-25 -20 111.0 61.0" version="1.1">
+width="111" height="101" viewBox="-25 -40 111.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,19 +22,35 @@ width="111" height="61" viewBox="-25 -20 111.0 61.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B_N</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B_N</text>
 </g>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_nor2b_2.svg
+++ b/docs/_static/symbols/sg13g2_nor2b_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="101" viewBox="-25 -40 111.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,36 +28,43 @@ width="111" height="101" viewBox="-25 -40 111.0 101.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B_N</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B_N</text>
 </g>
-<g transform="translate(60.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nor2b_2</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nor2b_2.svg
+++ b/docs/_static/symbols/sg13g2_nor2b_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="61" viewBox="-25 -20 111.0 61.0" version="1.1">
+width="111" height="101" viewBox="-25 -40 111.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,19 +22,35 @@ width="111" height="61" viewBox="-25 -20 111.0 61.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B_N</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B_N</text>
 </g>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_nor2b_2.svg
+++ b/docs/_static/symbols/sg13g2_nor2b_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,42 +29,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B_N</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B_N</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nor2b_2</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_nor2b_2</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nor3_1.svg
+++ b/docs/_static/symbols/sg13g2_nor3_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,40 +25,47 @@ width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nor3_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nor3_1.svg
+++ b/docs/_static/symbols/sg13g2_nor3_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,46 +26,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">C</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nor3_1</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_nor3_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nor3_1.svg
+++ b/docs/_static/symbols/sg13g2_nor3_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
+width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,23 +19,39 @@ width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_nor3_2.svg
+++ b/docs/_static/symbols/sg13g2_nor3_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,46 +26,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">C</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nor3_2</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_nor3_2</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nor3_2.svg
+++ b/docs/_static/symbols/sg13g2_nor3_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,40 +25,47 @@ width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nor3_2</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nor3_2.svg
+++ b/docs/_static/symbols/sg13g2_nor3_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
+width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,23 +19,39 @@ width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_nor4_1.svg
+++ b/docs/_static/symbols/sg13g2_nor4_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
+width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,27 +19,43 @@ width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
 <g transform="translate(0,60)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,75.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,75.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_nor4_1.svg
+++ b/docs/_static/symbols/sg13g2_nor4_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
+width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,50 +26,50 @@ width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">C</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
 </g>
-<g transform="translate(0,104.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<g transform="translate(0,114.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nor4_1</text>
-<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_nor4_1</text>
+<text class="fnt4" x="60.0" y="222.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nor4_1.svg
+++ b/docs/_static/symbols/sg13g2_nor4_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,44 +25,51 @@ width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
-<g transform="translate(0,60)">
+<g transform="translate(0,74.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,75.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,75.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,104.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nor4_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nor4_2.svg
+++ b/docs/_static/symbols/sg13g2_nor4_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
+width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,50 +26,50 @@ width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">C</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
 </g>
-<g transform="translate(0,104.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<g transform="translate(0,114.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nor4_2</text>
-<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_nor4_2</text>
+<text class="fnt4" x="60.0" y="222.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_nor4_2.svg
+++ b/docs/_static/symbols/sg13g2_nor4_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
+width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,27 +19,43 @@ width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
 <g transform="translate(0,60)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,75.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,75.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_nor4_2.svg
+++ b/docs/_static/symbols/sg13g2_nor4_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,44 +25,51 @@ width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
-<g transform="translate(0,60)">
+<g transform="translate(0,74.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,75.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,75.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,104.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_nor4_2</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_o21ai_1.svg
+++ b/docs/_static/symbols/sg13g2_o21ai_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,46 +26,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A1</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A2</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B1</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_o21ai_1</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_o21ai_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_o21ai_1.svg
+++ b/docs/_static/symbols/sg13g2_o21ai_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,40 +25,47 @@ width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
 </g>
-<g transform="translate(60.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_o21ai_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_o21ai_1.svg
+++ b/docs/_static/symbols/sg13g2_o21ai_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
+width="111" height="121" viewBox="-25 -40 111.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,23 +19,39 @@ width="111" height="81" viewBox="-25 -20 111.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A1</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A2</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A2</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B1</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B1</text>
 </g>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_or2_1.svg
+++ b/docs/_static/symbols/sg13g2_or2_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,36 +25,43 @@ width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_or2_1</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_or2_1.svg
+++ b/docs/_static/symbols/sg13g2_or2_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,42 +26,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_or2_1</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_or2_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_or2_1.svg
+++ b/docs/_static/symbols/sg13g2_or2_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,19 +19,35 @@ width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_or2_2.svg
+++ b/docs/_static/symbols/sg13g2_or2_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,36 +25,43 @@ width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_or2_2</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_or2_2.svg
+++ b/docs/_static/symbols/sg13g2_or2_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,19 +19,35 @@ width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_or2_2.svg
+++ b/docs/_static/symbols/sg13g2_or2_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,42 +26,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_or2_2</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_or2_2</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_or3_1.svg
+++ b/docs/_static/symbols/sg13g2_or3_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,40 +25,47 @@ width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_or3_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_or3_1.svg
+++ b/docs/_static/symbols/sg13g2_or3_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
+width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,23 +19,39 @@ width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_or3_1.svg
+++ b/docs/_static/symbols/sg13g2_or3_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,46 +26,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">C</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_or3_1</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_or3_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_or3_2.svg
+++ b/docs/_static/symbols/sg13g2_or3_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,46 +26,46 @@ width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">C</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_or3_2</text>
-<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_or3_2</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_or3_2.svg
+++ b/docs/_static/symbols/sg13g2_or3_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
+width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,23 +19,39 @@ width="91" height="81" viewBox="-25 -20 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_or3_2.svg
+++ b/docs/_static/symbols/sg13g2_or3_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,40 +25,47 @@ width="91" height="121" viewBox="-25 -40 91.0 121.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_or3_2</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_or4_1.svg
+++ b/docs/_static/symbols/sg13g2_or4_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,44 +25,51 @@ width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
-<g transform="translate(0,60)">
+<g transform="translate(0,74.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,75.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,75.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,104.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_or4_1</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_or4_1.svg
+++ b/docs/_static/symbols/sg13g2_or4_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
+width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,27 +19,43 @@ width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
 <g transform="translate(0,60)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,75.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,75.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_or4_1.svg
+++ b/docs/_static/symbols/sg13g2_or4_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
+width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,50 +26,50 @@ width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">C</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
 </g>
-<g transform="translate(0,104.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<g transform="translate(0,114.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_or4_1</text>
-<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_or4_1</text>
+<text class="fnt4" x="60.0" y="222.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_or4_2.svg
+++ b/docs/_static/symbols/sg13g2_or4_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
+width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,27 +19,43 @@ width="91" height="101" viewBox="-25 -20 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">C</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
 <g transform="translate(0,60)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,75.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,75.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_or4_2.svg
+++ b/docs/_static/symbols/sg13g2_or4_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
+width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,44 +25,51 @@ width="91" height="141" viewBox="-25 -40 91.0 141.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="90.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
 </g>
-<g transform="translate(0,60)">
+<g transform="translate(0,74.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,75.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,75.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="88.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,104.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_or4_2</text>
+<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_or4_2.svg
+++ b/docs/_static/symbols/sg13g2_or4_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
+width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,50 +26,50 @@ width="171" height="260" viewBox="-25 -44 171.0 260.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">C</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">C</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
 </g>
-<g transform="translate(0,104.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<g transform="translate(0,114.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_or4_2</text>
-<text class="fnt4" x="60.0" y="202.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_or4_2</text>
+<text class="fnt4" x="60.0" y="222.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_sdfbbp_1.svg
+++ b/docs/_static/symbols/sg13g2_sdfbbp_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="141" viewBox="-25 -20 151.0 141.0" version="1.1">
+width="151" height="181" viewBox="-25 -40 151.0 181.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,39 +26,55 @@ width="151" height="141" viewBox="-25 -20 151.0 141.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="100.0" height="130.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
 <g transform="translate(0,60)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCD</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
 </g>
 <g transform="translate(0,80)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCE</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
 </g>
 <g transform="translate(0,100)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SET_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SET_B</text>
 </g>
 <g transform="translate(100.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
 <g transform="translate(100.0,20)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q_N</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
+</g>
+<g transform="translate(33.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(66.66666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(33.333333333333336,115.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(66.66666666666667,115.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="98.0" height="128.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_sdfbbp_1.svg
+++ b/docs/_static/symbols/sg13g2_sdfbbp_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="191" height="300" viewBox="-25 -44 191.0 300.0" version="1.1">
+width="191" height="320" viewBox="-25 -44 191.0 320.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -23,72 +23,72 @@ width="191" height="300" viewBox="-25 -44 191.0 300.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="140.0" height="144.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="140.0" height="154.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">CLK</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">RESET_B</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">SCD</text>
 </g>
-<g transform="translate(0,94.4)">
+<g transform="translate(0,104.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">SCE</text>
 </g>
-<g transform="translate(0,114.4)">
+<g transform="translate(0,124.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">SET_B</text>
 </g>
-<g transform="translate(140.0,14.399999999999999)">
+<g transform="translate(140.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q</text>
 </g>
-<g transform="translate(140.0,34.4)">
+<g transform="translate(140.0,44.4)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q_N</text>
 </g>
 </g>
-<g transform="translate(0,144.4)">
-<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<g transform="translate(0,154.4)">
+<rect x="0" y="-15.0" width="140.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="138.0" height="246.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_sdfbbp_1</text>
-<text class="fnt4" x="70.0" y="242.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="138.0" height="266.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_sdfbbp_1</text>
+<text class="fnt4" x="70.0" y="262.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_sdfbbp_1.svg
+++ b/docs/_static/symbols/sg13g2_sdfbbp_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="181" viewBox="-25 -40 151.0 181.0" version="1.1">
+width="191" height="300" viewBox="-25 -44 191.0 300.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -17,65 +23,72 @@ width="151" height="181" viewBox="-25 -40 151.0 181.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="130.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="140.0" height="144.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
-<g transform="translate(0,60)">
+<g transform="translate(0,74.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
 </g>
-<g transform="translate(0,80)">
+<g transform="translate(0,94.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
 </g>
-<g transform="translate(0,100)">
+<g transform="translate(0,114.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SET_B</text>
 </g>
-<g transform="translate(100.0,0)">
+<g transform="translate(140.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
-<g transform="translate(100.0,20)">
+<g transform="translate(140.0,34.4)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
-</g>
-<g transform="translate(33.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(66.66666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(33.333333333333336,115.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(66.66666666666667,115.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="128.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,144.4)">
+<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="138.0" height="246.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_sdfbbp_1</text>
+<text class="fnt4" x="70.0" y="242.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_sdfrbp_1.svg
+++ b/docs/_static/symbols/sg13g2_sdfrbp_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="121" viewBox="-25 -20 151.0 121.0" version="1.1">
+width="151" height="161" viewBox="-25 -40 151.0 161.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,35 +26,51 @@ width="151" height="121" viewBox="-25 -20 151.0 121.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="100.0" height="110.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
 <g transform="translate(0,60)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCD</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
 </g>
 <g transform="translate(0,80)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCE</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
 </g>
 <g transform="translate(100.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
 <g transform="translate(100.0,20)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q_N</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
+</g>
+<g transform="translate(33.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(66.66666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(33.333333333333336,95.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(66.66666666666667,95.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="98.0" height="108.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_sdfrbp_1.svg
+++ b/docs/_static/symbols/sg13g2_sdfrbp_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="191" height="280" viewBox="-25 -44 191.0 280.0" version="1.1">
+width="191" height="300" viewBox="-25 -44 191.0 300.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -23,68 +23,68 @@ width="191" height="280" viewBox="-25 -44 191.0 280.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="140.0" height="124.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="140.0" height="134.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">CLK</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">RESET_B</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">SCD</text>
 </g>
-<g transform="translate(0,94.4)">
+<g transform="translate(0,104.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">SCE</text>
 </g>
-<g transform="translate(140.0,14.399999999999999)">
+<g transform="translate(140.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q</text>
 </g>
-<g transform="translate(140.0,34.4)">
+<g transform="translate(140.0,44.4)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q_N</text>
 </g>
 </g>
-<g transform="translate(0,124.4)">
-<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<g transform="translate(0,134.4)">
+<rect x="0" y="-15.0" width="140.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="138.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_sdfrbp_1</text>
-<text class="fnt4" x="70.0" y="222.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="138.0" height="246.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_sdfrbp_1</text>
+<text class="fnt4" x="70.0" y="242.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_sdfrbp_1.svg
+++ b/docs/_static/symbols/sg13g2_sdfrbp_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="161" viewBox="-25 -40 151.0 161.0" version="1.1">
+width="191" height="280" viewBox="-25 -44 191.0 280.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -17,61 +23,68 @@ width="151" height="161" viewBox="-25 -40 151.0 161.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="110.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="140.0" height="124.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
-<g transform="translate(0,60)">
+<g transform="translate(0,74.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
 </g>
-<g transform="translate(0,80)">
+<g transform="translate(0,94.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
 </g>
-<g transform="translate(100.0,0)">
+<g transform="translate(140.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
-<g transform="translate(100.0,20)">
+<g transform="translate(140.0,34.4)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
-</g>
-<g transform="translate(33.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(66.66666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(33.333333333333336,95.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(66.66666666666667,95.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="108.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,124.4)">
+<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="138.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_sdfrbp_1</text>
+<text class="fnt4" x="70.0" y="222.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_sdfrbp_2.svg
+++ b/docs/_static/symbols/sg13g2_sdfrbp_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="191" height="280" viewBox="-25 -44 191.0 280.0" version="1.1">
+width="191" height="300" viewBox="-25 -44 191.0 300.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -23,68 +23,68 @@ width="191" height="280" viewBox="-25 -44 191.0 280.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="140.0" height="124.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="140.0" height="134.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">CLK</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">RESET_B</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">SCD</text>
 </g>
-<g transform="translate(0,94.4)">
+<g transform="translate(0,104.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">SCE</text>
 </g>
-<g transform="translate(140.0,14.399999999999999)">
+<g transform="translate(140.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q</text>
 </g>
-<g transform="translate(140.0,34.4)">
+<g transform="translate(140.0,44.4)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q_N</text>
 </g>
 </g>
-<g transform="translate(0,124.4)">
-<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<g transform="translate(0,134.4)">
+<rect x="0" y="-15.0" width="140.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="138.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_sdfrbp_2</text>
-<text class="fnt4" x="70.0" y="222.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="138.0" height="246.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_sdfrbp_2</text>
+<text class="fnt4" x="70.0" y="242.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_sdfrbp_2.svg
+++ b/docs/_static/symbols/sg13g2_sdfrbp_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="121" viewBox="-25 -20 151.0 121.0" version="1.1">
+width="151" height="161" viewBox="-25 -40 151.0 161.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,35 +26,51 @@ width="151" height="121" viewBox="-25 -20 151.0 121.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="100.0" height="110.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
 <g transform="translate(0,60)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCD</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
 </g>
 <g transform="translate(0,80)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCE</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
 </g>
 <g transform="translate(100.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
 <g transform="translate(100.0,20)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q_N</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
+</g>
+<g transform="translate(33.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(66.66666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(33.333333333333336,95.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(66.66666666666667,95.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="98.0" height="108.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_sdfrbp_2.svg
+++ b/docs/_static/symbols/sg13g2_sdfrbp_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="161" viewBox="-25 -40 151.0 161.0" version="1.1">
+width="191" height="280" viewBox="-25 -44 191.0 280.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -17,61 +23,68 @@ width="151" height="161" viewBox="-25 -40 151.0 161.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="110.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="140.0" height="124.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
-<g transform="translate(0,60)">
+<g transform="translate(0,74.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
 </g>
-<g transform="translate(0,80)">
+<g transform="translate(0,94.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
 </g>
-<g transform="translate(100.0,0)">
+<g transform="translate(140.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
-<g transform="translate(100.0,20)">
+<g transform="translate(140.0,34.4)">
 <line x1="20" y1="0" x2="3.5" y2="-4.286263797015736e-16" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
-</g>
-<g transform="translate(33.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(66.66666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(33.333333333333336,95.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(66.66666666666667,95.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q_N</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="108.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,124.4)">
+<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="138.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_sdfrbp_2</text>
+<text class="fnt4" x="70.0" y="222.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_sdfrbpq_1.svg
+++ b/docs/_static/symbols/sg13g2_sdfrbpq_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="161" viewBox="-25 -40 151.0 161.0" version="1.1">
+width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -17,57 +23,64 @@ width="151" height="161" viewBox="-25 -40 151.0 161.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="110.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="124.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
-<g transform="translate(0,60)">
+<g transform="translate(0,74.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
 </g>
-<g transform="translate(0,80)">
+<g transform="translate(0,94.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
 </g>
-<g transform="translate(100.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
-</g>
-<g transform="translate(33.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(66.66666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(33.333333333333336,95.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(66.66666666666667,95.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="108.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,124.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_sdfrbpq_1</text>
+<text class="fnt4" x="60.0" y="222.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_sdfrbpq_1.svg
+++ b/docs/_static/symbols/sg13g2_sdfrbpq_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
+width="171" height="300" viewBox="-25 -44 171.0 300.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -23,64 +23,64 @@ width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="124.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="134.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">CLK</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">RESET_B</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">SCD</text>
 </g>
-<g transform="translate(0,94.4)">
+<g transform="translate(0,104.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">SCE</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q</text>
 </g>
 </g>
-<g transform="translate(0,124.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<g transform="translate(0,134.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_sdfrbpq_1</text>
-<text class="fnt4" x="60.0" y="222.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="246.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_sdfrbpq_1</text>
+<text class="fnt4" x="60.0" y="242.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_sdfrbpq_1.svg
+++ b/docs/_static/symbols/sg13g2_sdfrbpq_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="121" viewBox="-25 -20 151.0 121.0" version="1.1">
+width="151" height="161" viewBox="-25 -40 151.0 161.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,31 +26,47 @@ width="151" height="121" viewBox="-25 -20 151.0 121.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="100.0" height="110.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
 <g transform="translate(0,60)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCD</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
 </g>
 <g transform="translate(0,80)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCE</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
 </g>
 <g transform="translate(100.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+</g>
+<g transform="translate(33.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(66.66666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(33.333333333333336,95.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(66.66666666666667,95.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="98.0" height="108.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_sdfrbpq_2.svg
+++ b/docs/_static/symbols/sg13g2_sdfrbpq_2.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="161" viewBox="-25 -40 151.0 161.0" version="1.1">
+width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -17,57 +23,64 @@ width="151" height="161" viewBox="-25 -40 151.0 161.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="110.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="124.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
-<g transform="translate(0,60)">
+<g transform="translate(0,74.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
 </g>
-<g transform="translate(0,80)">
+<g transform="translate(0,94.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
 </g>
-<g transform="translate(100.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
-</g>
-<g transform="translate(33.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(66.66666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(33.333333333333336,95.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(66.66666666666667,95.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="108.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,124.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_sdfrbpq_2</text>
+<text class="fnt4" x="60.0" y="222.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_sdfrbpq_2.svg
+++ b/docs/_static/symbols/sg13g2_sdfrbpq_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
+width="171" height="300" viewBox="-25 -44 171.0 300.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -23,64 +23,64 @@ width="171" height="280" viewBox="-25 -44 171.0 280.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
-</g>
-</marker>
 <marker id="clock" markerWidth="8.0" markerHeight="15.0" viewBox="0 0 8.0 15.0" refX="0.5" refY="7.5" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(0.5,7.5)"><path d="M 0 -7 L 0 7 L 7 0 z" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
 </g>
 </marker>
+<marker id="bubble" markerWidth="7.0" markerHeight="7.0" viewBox="0 0 7.0 7.0" refX="3.5" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(3.5,3.5)"><ellipse cx="0.0" cy="0.0" rx="3.0" ry="3.0" stroke="#000000" fill="#FFFFFF" stroke-width="1"/>
+</g>
+</marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="124.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="134.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">CLK</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">D</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">RESET_B</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">SCD</text>
 </g>
-<g transform="translate(0,94.4)">
+<g transform="translate(0,104.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">SCE</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Q</text>
 </g>
 </g>
-<g transform="translate(0,124.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
+<g transform="translate(0,134.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,84.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="226.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_sdfrbpq_2</text>
-<text class="fnt4" x="60.0" y="222.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="246.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_sdfrbpq_2</text>
+<text class="fnt4" x="60.0" y="242.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_sdfrbpq_2.svg
+++ b/docs/_static/symbols/sg13g2_sdfrbpq_2.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="121" viewBox="-25 -20 151.0 121.0" version="1.1">
+width="151" height="161" viewBox="-25 -40 151.0 161.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,31 +26,47 @@ width="151" height="121" viewBox="-25 -20 151.0 121.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="100.0" height="110.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">D</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">D</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="-3.5" y2="0.0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#bubble)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">RESET_B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">RESET_B</text>
 </g>
 <g transform="translate(0,60)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCD</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCD</text>
 </g>
 <g transform="translate(0,80)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCE</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
 </g>
 <g transform="translate(100.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Q</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Q</text>
+</g>
+<g transform="translate(33.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(66.66666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(33.333333333333336,95.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(66.66666666666667,95.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="98.0" height="108.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_sighold.svg
+++ b/docs/_static/symbols/sg13g2_sighold.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="200" viewBox="-25 -44 151.0 200.0" version="1.1">
+width="151" height="220" viewBox="-25 -44 151.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -23,44 +23,44 @@ width="151" height="200" viewBox="-25 -44 151.0 200.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="arrow_back" markerWidth="8.0" markerHeight="8.0" viewBox="0 0 8.0 8.0" refX="4.8" refY="4.0" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(8.0,4.0)"><path d="M 0 -4 C -2 -1, -2 1, 0 4 L -8 0 z" stroke="none" fill="#000000"/>
-</g>
-</marker>
 <marker id="arrow_fwd" markerWidth="8.0" markerHeight="8.0" viewBox="0 0 8.0 8.0" refX="3.2" refY="4.0" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(-0.0,4.0)"><path d="M 0 -4 C 2 -1, 2 1, 0 4 L 8 0 z" stroke="none" fill="#000000"/>
 </g>
 </marker>
+<marker id="arrow_back" markerWidth="8.0" markerHeight="8.0" viewBox="0 0 8.0 8.0" refX="4.8" refY="4.0" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(8.0,4.0)"><path d="M 0 -4 C -2 -1, -2 1, 0 4 L -8 0 z" stroke="none" fill="#000000"/>
+</g>
+</marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(100.0,14.399999999999999)">
+<rect x="0" y="-15.0" width="100.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(100.0,24.4)">
 <line x1="16.16" y1="4.702643708725836e-16" x2="3.84" y2="-4.702643708725836e-16" stroke="#000000" fill="none" stroke-width="1" marker-start="url(#arrow_back)" marker-end="url(#arrow_fwd)"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">SH</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">SH</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="100.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="100.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="50.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_sighold</text>
-<text class="fnt4" x="50.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="98.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="50.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_sighold</text>
+<text class="fnt4" x="50.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_sighold.svg
+++ b/docs/_static/symbols/sg13g2_sighold.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="71" height="41" viewBox="-5 -20 71.0 41.0" version="1.1">
+width="71" height="81" viewBox="-6 -40 71.56666666666666 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,11 +26,27 @@ width="71" height="41" viewBox="-5 -20 71.0 41.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-5" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-6" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(40.0,0)">
 <line x1="16.16" y1="4.702643708725836e-16" x2="3.84" y2="-4.702643708725836e-16" stroke="#000000" fill="none" stroke-width="1" marker-start="url(#arrow_back)" marker-end="url(#arrow_fwd)"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">SH</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">SH</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_sighold.svg
+++ b/docs/_static/symbols/sg13g2_sighold.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="71" height="81" viewBox="-6 -40 71.56666666666666 81.0" version="1.1">
+width="151" height="200" viewBox="-25 -44 151.0 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -17,37 +23,44 @@ width="71" height="81" viewBox="-6 -40 71.56666666666666 81.0" version="1.1">
 ]]>
 </style>
 <defs>
-<marker id="arrow_fwd" markerWidth="8.0" markerHeight="8.0" viewBox="0 0 8.0 8.0" refX="3.2" refY="4.0" orient="auto" markerUnits="userSpaceOnUse">
-<g transform="translate(-0.0,4.0)"><path d="M 0 -4 C 2 -1, 2 1, 0 4 L 8 0 z" stroke="none" fill="#000000"/>
-</g>
-</marker>
 <marker id="arrow_back" markerWidth="8.0" markerHeight="8.0" viewBox="0 0 8.0 8.0" refX="4.8" refY="4.0" orient="auto" markerUnits="userSpaceOnUse">
 <g transform="translate(8.0,4.0)"><path d="M 0 -4 C -2 -1, -2 1, 0 4 L -8 0 z" stroke="none" fill="#000000"/>
 </g>
 </marker>
+<marker id="arrow_fwd" markerWidth="8.0" markerHeight="8.0" viewBox="0 0 8.0 8.0" refX="3.2" refY="4.0" orient="auto" markerUnits="userSpaceOnUse">
+<g transform="translate(-0.0,4.0)"><path d="M 0 -4 C 2 -1, 2 1, 0 4 L 8 0 z" stroke="none" fill="#000000"/>
+</g>
+</marker>
 </defs>
-<rect x="-6" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(40.0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(100.0,14.399999999999999)">
 <line x1="16.16" y1="4.702643708725836e-16" x2="3.84" y2="-4.702643708725836e-16" stroke="#000000" fill="none" stroke-width="1" marker-start="url(#arrow_back)" marker-end="url(#arrow_fwd)"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">SH</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">SH</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="100.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="50.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_sighold</text>
+<text class="fnt4" x="50.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_slgcp_1.svg
+++ b/docs/_static/symbols/sg13g2_slgcp_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="191" height="240" viewBox="-25 -44 191.0 240.0" version="1.1">
+width="191" height="260" viewBox="-25 -44 191.0 260.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -29,46 +29,46 @@ width="191" height="240" viewBox="-25 -44 191.0 240.0" version="1.1">
 </marker>
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="140.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="140.0" height="94.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">GATE</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">CLK</text>
 </g>
-<g transform="translate(0,54.4)">
+<g transform="translate(0,64.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">SCE</text>
 </g>
-<g transform="translate(140.0,14.399999999999999)">
+<g transform="translate(140.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">GCLK</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">GCLK</text>
 </g>
+</g>
+<g transform="translate(0,94.4)">
+<rect x="0" y="-15.0" width="140.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
 </g>
 <g transform="translate(0,84.4)">
-<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
-</g>
-<g transform="translate(0,74.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="138.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_slgcp_1</text>
-<text class="fnt4" x="70.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="138.0" height="206.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_slgcp_1</text>
+<text class="fnt4" x="70.0" y="202.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_slgcp_1.svg
+++ b/docs/_static/symbols/sg13g2_slgcp_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
+width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -22,23 +22,39 @@ width="151" height="81" viewBox="-25 -20 151.0 81.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">GATE</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">CLK</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
 <g transform="translate(0,40)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">SCE</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
 </g>
 <g transform="translate(100.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">GCLK</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">GCLK</text>
+</g>
+<g transform="translate(33.333333333333336,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(66.66666666666667,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(33.333333333333336,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(66.66666666666667,55.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_slgcp_1.svg
+++ b/docs/_static/symbols/sg13g2_slgcp_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
+width="191" height="240" viewBox="-25 -44 191.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -22,40 +28,47 @@ width="151" height="121" viewBox="-25 -40 151.0 121.0" version="1.1">
 </g>
 </marker>
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="70.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="140.0" height="84.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">GATE</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">CLK</text>
 </g>
-<g transform="translate(0,40)">
+<g transform="translate(0,54.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">SCE</text>
 </g>
-<g transform="translate(100.0,0)">
+<g transform="translate(140.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">GCLK</text>
-</g>
-<g transform="translate(33.333333333333336,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(66.66666666666667,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(33.333333333333336,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(66.66666666666667,55.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">GCLK</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="68.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,84.4)">
+<rect x="0" y="-15.0" width="140.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="70.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="138.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="70.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_slgcp_1</text>
+<text class="fnt4" x="70.0" y="182.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_tiehi.svg
+++ b/docs/_static/symbols/sg13g2_tiehi.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-5 -40 91.0 81.0" version="1.1">
+width="151" height="200" viewBox="-25 -44 151.0 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,28 +25,35 @@ width="91" height="81" viewBox="-5 -40 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-5" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(60.0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(100.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">L_HI</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">L_HI</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="100.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="50.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_tiehi</text>
+<text class="fnt4" x="50.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_tiehi.svg
+++ b/docs/_static/symbols/sg13g2_tiehi.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="200" viewBox="-25 -44 151.0 200.0" version="1.1">
+width="151" height="220" viewBox="-25 -44 151.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,34 +26,34 @@ width="151" height="200" viewBox="-25 -44 151.0 200.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(100.0,14.399999999999999)">
+<rect x="0" y="-15.0" width="100.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(100.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">L_HI</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">L_HI</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="100.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="100.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="50.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_tiehi</text>
-<text class="fnt4" x="50.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="98.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="50.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_tiehi</text>
+<text class="fnt4" x="50.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_tiehi.svg
+++ b/docs/_static/symbols/sg13g2_tiehi.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="41" viewBox="-5 -20 91.0 41.0" version="1.1">
+width="91" height="81" viewBox="-5 -40 91.0 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,11 +19,27 @@ width="91" height="41" viewBox="-5 -20 91.0 41.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-5" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-5" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">L_HI</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">L_HI</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_tielo.svg
+++ b/docs/_static/symbols/sg13g2_tielo.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="81" viewBox="-5 -40 91.0 81.0" version="1.1">
+width="151" height="200" viewBox="-25 -44 151.0 200.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,28 +25,35 @@ width="91" height="81" viewBox="-5 -40 91.0 81.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-5" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="60.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(60.0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="100.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(100.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">L_LO</text>
-</g>
-<g transform="translate(20.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(40.0,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(20.0,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(40.0,15.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">L_LO</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="58.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,44.4)">
+<rect x="0" y="-15.0" width="100.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="98.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="50.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_tielo</text>
+<text class="fnt4" x="50.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_tielo.svg
+++ b/docs/_static/symbols/sg13g2_tielo.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="151" height="200" viewBox="-25 -44 151.0 200.0" version="1.1">
+width="151" height="220" viewBox="-25 -44 151.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,34 +26,34 @@ width="151" height="200" viewBox="-25 -44 151.0 200.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="100.0" height="44.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(100.0,14.399999999999999)">
+<rect x="0" y="-15.0" width="100.0" height="54.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(100.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">L_LO</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">L_LO</text>
 </g>
-</g>
-<g transform="translate(0,44.4)">
-<rect x="0" y="-15.0" width="100.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
 </g>
 <g transform="translate(0,54.4)">
+<rect x="0" y="-15.0" width="100.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="50.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
 </g>
-<g transform="translate(0,74.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="98.0" height="146.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="50.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_tielo</text>
-<text class="fnt4" x="50.0" y="142.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="98.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="50.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_tielo</text>
+<text class="fnt4" x="50.0" y="162.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_tielo.svg
+++ b/docs/_static/symbols/sg13g2_tielo.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="41" viewBox="-5 -20 91.0 41.0" version="1.1">
+width="91" height="81" viewBox="-5 -40 91.0 81.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,11 +19,27 @@ width="91" height="41" viewBox="-5 -20 91.0 41.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-5" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-5" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="60.0" height="30.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(60.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">L_LO</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">L_LO</text>
+</g>
+<g transform="translate(20.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(40.0,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(20.0,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(40.0,15.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="58.0" height="28.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_xnor2_1.svg
+++ b/docs/_static/symbols/sg13g2_xnor2_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,36 +25,43 @@ width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_xnor2_1</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_xnor2_1.svg
+++ b/docs/_static/symbols/sg13g2_xnor2_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,42 +26,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">Y</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_xnor2_1</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_xnor2_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_xnor2_1.svg
+++ b/docs/_static/symbols/sg13g2_xnor2_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,19 +19,35 @@ width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">Y</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">Y</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/docs/_static/symbols/sg13g2_xor2_1.svg
+++ b/docs/_static/symbols/sg13g2_xor2_1.svg
@@ -3,11 +3,17 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
+width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
+    font-family:Times; font-size:12pt; font-weight:normal; font-style:italic;}
+.fnt2 {fill:#000000;
     font-family:Helvetica; font-size:12pt; font-weight:normal; font-style:normal;}
+.fnt3 {fill:#000000;
+    font-family:Helvetica; font-size:16pt; font-weight:bold; font-style:normal;}
+.fnt4 {fill:#000000;
+    font-family:Helvetica; font-size:10pt; font-weight:normal; font-style:normal;}
 .label {fill:#000;
   text-anchor:middle;
   font-size:16pt; font-weight:bold; font-family:Sans;}
@@ -19,36 +25,43 @@ width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<g transform="translate(0,0)">
+<rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
+<g transform="translate(0,14.399999999999999)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
-<g transform="translate(0,20)">
+<g transform="translate(0,34.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
-<g transform="translate(40.0,0)">
+<g transform="translate(120.0,14.399999999999999)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
-</g>
-<g transform="translate(13.333333333333334,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
-</g>
-<g transform="translate(26.666666666666668,-15.0)">
-<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
-</g>
-<g transform="translate(13.333333333333334,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
-</g>
-<g transform="translate(26.666666666666668,35.0)">
-<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>
+<g transform="translate(0,64.4)">
+<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
+<g transform="translate(0,14.399999999999999)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
+</g>
+<g transform="translate(0,34.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
+</g>
+<g transform="translate(0,54.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
+</g>
+<g transform="translate(0,74.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+</g>
+</g>
+<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_xor2_1</text>
+<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_xor2_1.svg
+++ b/docs/_static/symbols/sg13g2_xor2_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
+width="171" height="240" viewBox="-25 -44 171.0 240.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -26,42 +26,42 @@ width="171" height="220" viewBox="-25 -44 171.0 220.0" version="1.1">
 
 </defs>
 <rect x="-25" y="-44" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="120.0" height="64.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Data Signals</text>
-<g transform="translate(0,14.399999999999999)">
+<rect x="0" y="-15.0" width="120.0" height="74.4" stroke="#000000" fill="#CCFED2" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Data Signals</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">A</text>
 </g>
-<g transform="translate(0,34.4)">
+<g transform="translate(0,44.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">B</text>
 </g>
-<g transform="translate(120.0,14.399999999999999)">
+<g transform="translate(120.0,24.4)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+<text class="fnt2" x="-10" y="0" text-anchor="end" dy="5.4719999999999995">X</text>
 </g>
-</g>
-<g transform="translate(0,64.4)">
-<rect x="0" y="-15.0" width="120.0" height="104.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
-<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="-7.199999999999999">Power</text>
-<g transform="translate(0,14.399999999999999)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPB</text>
-</g>
-<g transform="translate(0,34.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VPWR</text>
-</g>
-<g transform="translate(0,54.4)">
-<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VGND</text>
 </g>
 <g transform="translate(0,74.4)">
+<rect x="0" y="-15.0" width="120.0" height="114.4" stroke="#000000" fill="#FECFCF" stroke-width="1"/>
+<text class="fnt1" x="60.0" y="0" text-anchor="middle" dy="5.4719999999999995">Power</text>
+<g transform="translate(0,24.4)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt2" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">VNB</text>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPB</text>
+</g>
+<g transform="translate(0,44.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VPWR</text>
+</g>
+<g transform="translate(0,64.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VGND</text>
+</g>
+<g transform="translate(0,84.4)">
+<line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt2" x="10" y="0" text-anchor="normal" dy="5.4719999999999995">VNB</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="118.0" height="166.8" stroke="#000000" fill="none" stroke-width="3"/>
-<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="-15.2">sg13g2_xor2_1</text>
-<text class="fnt4" x="60.0" y="162.8" text-anchor="middle" dy="-4.0">sg13g2_stdcell</text>
+<rect x="1.0" y="-14.0" width="118.0" height="186.8" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt3" x="60.0" y="-24.0" text-anchor="middle" dy="1.6960000000000015">sg13g2_xor2_1</text>
+<text class="fnt4" x="60.0" y="182.8" text-anchor="middle" dy="6.5600000000000005">sg13g2_stdcell</text>
 </svg>

--- a/docs/_static/symbols/sg13g2_xor2_1.svg
+++ b/docs/_static/symbols/sg13g2_xor2_1.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
+width="91" height="101" viewBox="-25 -40 91.0 101.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -19,19 +19,35 @@ width="91" height="61" viewBox="-25 -20 91.0 61.0" version="1.1">
 <defs>
 
 </defs>
-<rect x="-25" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
+<rect x="-25" y="-40" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
 <rect x="0" y="-15.0" width="40.0" height="50.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">A</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">A</text>
 </g>
 <g transform="translate(0,20)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="10" y="0" text-anchor="normal" dy="4.800000000000001">B</text>
+<text class="fnt1" x="10" y="0" text-anchor="normal" dy="-7.199999999999999">B</text>
 </g>
 <g transform="translate(40.0,0)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="4.800000000000001">X</text>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="-7.199999999999999">X</text>
+</g>
+<g transform="translate(13.333333333333334,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPWR</text>
+</g>
+<g transform="translate(26.666666666666668,-15.0)">
+<line x1="0" y1="-20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="10" text-anchor="middle" dy="-4.0">VPB</text>
+</g>
+<g transform="translate(13.333333333333334,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VGND</text>
+</g>
+<g transform="translate(26.666666666666668,35.0)">
+<line x1="0" y1="20" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
+<text class="fnt1" x="0" y="-10" text-anchor="middle" dy="-10.399999999999999">VNB</text>
 </g>
 </g>
 <rect x="1.0" y="-14.0" width="38.0" height="48.0" stroke="#000000" fill="none" stroke-width="3"/>

--- a/scripts/generate_symbols.py
+++ b/scripts/generate_symbols.py
@@ -10,11 +10,11 @@ repo_root = os.path.abspath(os.path.join(script_dir, ".."))
 sys.path.append(os.path.join(repo_root, "symbolator"))
 sys.path.append(os.path.join(repo_root, "hdlparse"))
 
-from symbolator import make_symbol, HdlSymbol, DrawStyle
-from nucanvas import NuCanvas
+from symbolator import make_symbol, HdlSymbol
+from nucanvas.nucanvas import NuCanvas, DrawStyle
 from nucanvas.svg_backend import SvgSurface
 from nucanvas.shapes import PathShape, OvalShape
-from hdlparse import verilog_parser as vlog
+from hdlparse.verilog_parser import VerilogExtractor, VerilogParameter
 
 def generate_symbols():
     verilog_path = os.path.join(repo_root, "ihp-sg13g2/libs.ref/sg13g2_stdcell/verilog/sg13g2_stdcell.v")
@@ -24,7 +24,7 @@ def generate_symbols():
         os.makedirs(output_dir)
 
     print(f"Parsing Verilog: {verilog_path}")
-    vlog_ex = vlog.VerilogExtractor()
+    vlog_ex = VerilogExtractor()
     components = vlog_ex.extract_objects(verilog_path)
     print(f"Found {len(components)} components.")
 
@@ -50,6 +50,17 @@ def generate_symbols():
                   (0, 0), 'auto', None)
 
     for comp in components:
+        # Inject power and bias pins
+        # comp.ports is a list in older hdlparse but odict_values in newer?
+        # Let's check the type and handle accordingly
+        if not isinstance(comp.ports, list):
+            comp.ports = list(comp.ports)
+
+        comp.ports.append(VerilogParameter('VPWR', 'input', 'wire'))
+        comp.ports.append(VerilogParameter('VPB', 'input', 'wire'))
+        comp.ports.append(VerilogParameter('VGND', 'input', 'wire'))
+        comp.ports.append(VerilogParameter('VNB', 'input', 'wire'))
+
         fname = os.path.join(output_dir, f"{comp.name}.svg")
         print(f"Generating symbol for {comp.name} -> {fname}")
 

--- a/scripts/generate_symbols.py
+++ b/scripts/generate_symbols.py
@@ -56,8 +56,11 @@ def generate_symbols():
         if not isinstance(comp.ports, list):
             comp.ports = list(comp.ports)
 
-        comp.ports.append(VerilogParameter('VPWR', 'input', 'wire'))
+        num_orig_ports = len(comp.ports)
+        comp.sections = {0: 'data | Data Signals', num_orig_ports: 'power | Power'}
+
         comp.ports.append(VerilogParameter('VPB', 'input', 'wire'))
+        comp.ports.append(VerilogParameter('VPWR', 'input', 'wire'))
         comp.ports.append(VerilogParameter('VGND', 'input', 'wire'))
         comp.ports.append(VerilogParameter('VNB', 'input', 'wire'))
 
@@ -68,7 +71,8 @@ def generate_symbols():
         nc.set_surface(surf)
         nc.clear_shapes()
 
-        sym = make_symbol(comp, vlog_ex, title=False, no_type=True)
+        sym = make_symbol(comp, vlog_ex, title=True, no_type=True)
+        sym.library = "sg13g2_stdcell"
         sym.draw(0, 0, nc)
         nc.render()
 


### PR DESCRIPTION
This change includes power (VPWR, VGND) and bias (VPB, VNB) signals in the standard cell symbols, matching the style used in other PDKs like SKY130.

Key changes:
1.  **Symbolator Enhancement**: Modified `symbolator/symbolator.py` and its dependencies to support 'top' and 'bottom' pin sides. This involved updating the `Pin` and `PinSection` classes to handle vertical whiskers and appropriate label anchoring.
2.  **Pin Injection**: Updated `scripts/generate_symbols.py` to automatically add the power and bias pins to every standard cell component parsed from the Verilog netlist.
3.  **Submodule Compatibility**: Resolved several Python 3 incompatibilities and import issues within the `symbolator` and `hdlparse` submodules that were blocking the generation pipeline in the current environment.
4.  **Symbol Regeneration**: Regenerated all 84 SVG symbols in `docs/_static/symbols/`.

These changes ensure that the documentation symbols provide a complete representation of the cell interfaces, including power and bulk connections.

Fixes #61

---
*PR created automatically by Jules for task [13654384680748954409](https://jules.google.com/task/13654384680748954409) started by @chatelao*